### PR TITLE
Fix/GH-137-RefreshToken-Reuse-Bug

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
@@ -44,16 +44,18 @@ public class AuthController {
 	}
 
 	@PostMapping("/refresh")
-	@Operation(summary = "Refresh Token을 이용한 Access Token 재발급 메서드", description = "Refresh Token을 이용하여 Access Token을 재발급 받기 위한 메서드입니다.")
+	@Operation(summary = "Refresh Token을 이용한 New RefreshToken, New Access Token 발급 메서드", description = "Refresh Token을 이용하여 새로운 Refresh Token, Access Token을 발급 받기 위한 메서드입니다.")
 	public TokenDto reissueAccessToken(@RequestHeader("Authorization") String refreshToken) {
 		String newAccessToken = refreshTokenService.createNewAccessTokenByValidateRefreshToken(refreshToken);
-
-		refreshToken = refreshToken.substring(7);
+		String newRefreshToken = refreshTokenService.createNewRefreshTokenByValidateRefreshToken(refreshToken);
 
 		TokenDto tokenDto = TokenDto.builder()
 				.accessToken(newAccessToken)
-				.refreshToken(refreshToken)
+				.refreshToken(newRefreshToken)
 				.build();
+
+		refreshToken = refreshToken.substring(7);
+		refreshTokenService.storeRefreshToken(tokenDto, jwtProvider.getUsername(refreshToken));
 
 		return tokenDto;
 	}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### 작업사항
- #32  **수정**
1. 헤더에 refresh token을 담아 `/refresh `endpoint에 요청을 보낸다.
2. refresh token이 유효하다
    - 새로운 access token과 refresh token을 발급한다.
3. refresh token이 유효하지 않다
    - refresh token이 유효 기간이 만료 되었다
        - Spring Security에 의한 401 에러
    - refresh token이 유효 기간이 만료되지 않았으나, refresh_token 테이블에 저장된 값이 아니다.
        - BusinessException에 의한 401 에러

### 화면캡처(선택)

### 의문점(선택) 