### PR TITLE
feat/GH-111-logout

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
@@ -119,4 +119,11 @@ public class AuthController {
 		String idToken = appleService.getIdToken(code, clientSecretKey);
 		return appleService.getToken(idToken);
 	}
+
+	@PostMapping("/sign-out")
+	@Operation(summary = "로그아웃 메서드", description = "사용자가 로그아웃을 하기 위한 메서드입니다.")
+	public void signOut(HttpServletRequest request) {
+		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
+		authService.signOut(username);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
@@ -6,4 +6,6 @@ import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 public interface AuthService {
 
 	TokenDto signIn(SignInDto loginDto);
+
+	void signOut(String username);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -38,6 +39,14 @@ public class AuthServiceImpl implements AuthService {
 		refreshTokenService.storeRefreshToken(tokenDto, member.getUsername());
 
 		return tokenDto;
+	}
 
+	@Transactional
+	public void signOut(String username) {
+		Member member = memberRepository.findByUsername(username);
+		if (member == null) {
+			throw new BusinessException("존재하지 않는 아이디입니다.", ErrorCode.INVALID_INPUT_VALUE);
+		}
+		refreshTokenService.deleteRefreshToken(username);
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
@@ -45,7 +45,7 @@ public class AuthServiceImpl implements AuthService {
 	public void signOut(String username) {
 		Member member = memberRepository.findByUsername(username);
 		if (member == null) {
-			throw new BusinessException("존재하지 않는 아이디입니다.", ErrorCode.INVALID_INPUT_VALUE);
+			throw new BusinessException("존재하지 않는 사용자입니다.", ErrorCode.INVALID_AUTHENTICATION);
 		}
 		refreshTokenService.deleteRefreshToken(username);
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/RefreshTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/RefreshTokenService.java
@@ -7,7 +7,11 @@ import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.RefreshToken;
 import org.swmaestro.repl.gifthub.auth.repository.RefreshTokenRepository;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
+import org.swmaestro.repl.gifthub.exception.ErrorCode;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -43,5 +47,14 @@ public class RefreshTokenService {
 			return jwtProvider.generateRefreshToken(jwtProvider.getUsername(refreshToken));
 		}
 		return null;
+	}
+
+	public void deleteRefreshToken(String username) {
+		Optional<RefreshToken> refreshToken = refreshTokenRepository.findByUsername(username);
+		if (refreshToken.isPresent()) {
+			refreshTokenRepository.delete(refreshToken.get());
+		} else {
+			throw new BusinessException("존재하지 않는 사용자 입니다.", ErrorCode.INVALID_AUTHENTICATION);
+		}
 	}
 }

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.swmaestro.repl.gifthub.auth.dto.*;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
@@ -231,5 +232,20 @@ public class AuthControllerTest {
 						.requestAttr("code", "my_awesome_code")
 						.header("Authorization", "Bearer " + accesstoken))
 				.andExpect(status().isBadRequest());
+	}
+
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	public void signOutTest() throws Exception {
+		String username = "jinlee1703";
+		String accessToken = "my_awesome_access_token";
+
+		when(jwtProvider.getUsername(accessToken)).thenReturn(username);
+		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
+
+		mockMvc.perform(post("/auth/sign-out")
+						.header("Authorization", "Bearer " + accessToken))
+				.andExpect(status().isOk());
+
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### 작업사항
- 로그 아웃 테스트 코드 작성
- 로그 아웃 로직 구현
  - 로그 아웃 요청 시, refresh token 테이블에서 사용자의 refresh token을 삭제한다.
    - 성공 시: 200 ok
    - 실패 시: 401 error
- 로그 아웃 API 구현
  - `auth/sign-out`

### 화면캡처(선택)

### 의문점(선택) 