### PR TITLE
feat/GH-149-member-delete

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -1,0 +1,26 @@
+package org.swmaestro.repl.gifthub.auth.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.service.MemberService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Tag(name = "Users", description = "사용자 관련 API")
+public class UserController {
+	private final MemberService memberService;
+
+	@DeleteMapping("/{userId}")
+	@Operation(summary = "User 삭제 메서드", description = "클라이언트에서 요청한 사용자 정보를 삭제(Soft-Delete)하기 위한 메서드입니다.")
+	public UserDeleteResponseDto deleteMember(@PathVariable Long userId) {
+		return memberService.delete(userId);
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -4,7 +4,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +20,7 @@ public class UserController {
 
 	@DeleteMapping("/{userId}")
 	@Operation(summary = "User 삭제 메서드", description = "클라이언트에서 요청한 사용자 정보를 삭제(Soft-Delete)하기 위한 메서드입니다.")
-	public UserDeleteResponseDto deleteMember(@PathVariable Long userId) {
+	public MemberDeleteResponseDto deleteMember(@PathVariable Long userId) {
 		return memberService.delete(userId);
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberDeleteResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberDeleteResponseDto.java
@@ -11,11 +11,11 @@ import lombok.ToString;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserDeleteResponseDto implements Serializable {
+public class MemberDeleteResponseDto implements Serializable {
 	private Long id;
 
 	@Builder
-	public UserDeleteResponseDto(Long id) {
+	public MemberDeleteResponseDto(Long id) {
 		this.id = id;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserDeleteResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserDeleteResponseDto.java
@@ -1,0 +1,21 @@
+package org.swmaestro.repl.gifthub.auth.dto;
+
+import java.io.Serializable;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDeleteResponseDto implements Serializable {
+	private Long id;
+
+	@Builder
+	public UserDeleteResponseDto(Long id) {
+		this.id = id;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/Member.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/Member.java
@@ -1,5 +1,7 @@
 package org.swmaestro.repl.gifthub.auth.entity;
 
+import java.time.LocalDateTime;
+
 import org.swmaestro.repl.gifthub.util.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -30,6 +32,9 @@ public class Member extends BaseTimeEntity {
 
 	@Column(length = 12, nullable = false)
 	private String nickname;
+
+	@Column
+	private LocalDateTime deletedAt;
 
 	@Builder
 	public Member(Long id, String username, String password, String nickname) {

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
@@ -1,10 +1,11 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
+import java.util.List;
+
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
+import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
-
-import java.util.List;
 
 public interface MemberService {
 	TokenDto create(SignUpDto signUpDTO);
@@ -23,5 +24,5 @@ public interface MemberService {
 
 	Long update(Long id, Member member);
 
-	Long delete(Long id);
+	UserDeleteResponseDto delete(Long id);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
@@ -2,9 +2,9 @@ package org.swmaestro.repl.gifthub.auth.service;
 
 import java.util.List;
 
+import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
-import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 
 public interface MemberService {
@@ -24,5 +24,5 @@ public interface MemberService {
 
 	Long update(Long id, Member member);
 
-	UserDeleteResponseDto delete(Long id);
+	MemberDeleteResponseDto delete(Long id);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
@@ -1,19 +1,22 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
+import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.repository.MemberRepository;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.exception.ErrorCode;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +28,10 @@ public class MemberServiceImpl implements MemberService {
 
 	public Member passwordEncryption(Member member) {
 		return Member.builder()
-				.username(member.getUsername())
-				.password(passwordEncoder.encode(member.getPassword()))
-				.nickname(member.getNickname())
-				.build();
+			.username(member.getUsername())
+			.password(passwordEncoder.encode(member.getPassword()))
+			.nickname(member.getNickname())
+			.build();
 	}
 
 	@Override
@@ -49,9 +52,9 @@ public class MemberServiceImpl implements MemberService {
 		String refreshToken = jwtProvider.generateRefreshToken(encodedMember.getUsername());
 
 		TokenDto tokenDto = TokenDto.builder()
-				.accessToken(accessToken)
-				.refreshToken(refreshToken)
-				.build();
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
 
 		refreshTokenService.storeRefreshToken(tokenDto, encodedMember.getUsername());
 
@@ -60,10 +63,10 @@ public class MemberServiceImpl implements MemberService {
 
 	public Member convertSignUpDTOtoMember(SignUpDto signUpDTO) {
 		return Member.builder()
-				.username(signUpDTO.getUsername())
-				.password(signUpDTO.getPassword())
-				.nickname(signUpDTO.getNickname())
-				.build();
+			.username(signUpDTO.getUsername())
+			.password(signUpDTO.getPassword())
+			.nickname(signUpDTO.getNickname())
+			.build();
 	}
 
 	public boolean isDuplicateUsername(String username) {
@@ -89,7 +92,7 @@ public class MemberServiceImpl implements MemberService {
 
 	@Override
 	public int count() {
-		return (int) memberRepository.count();
+		return (int)memberRepository.count();
 	}
 
 	@Override
@@ -103,7 +106,14 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public Long delete(Long id) {
-		return null;
+	public UserDeleteResponseDto delete(Long id) {
+		Member member = memberRepository.findById(id)
+			.orElseThrow(() -> new BusinessException("존재하지 않는 회원입니다.", ErrorCode.NOT_FOUND_RESOURCE));
+
+		member.setDeletedAt(LocalDateTime.now());
+
+		return UserDeleteResponseDto.builder()
+			.id(id)
+			.build();
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
@@ -7,9 +7,9 @@ import java.util.regex.Pattern;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
-import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.repository.MemberRepository;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
@@ -106,13 +106,14 @@ public class MemberServiceImpl implements MemberService {
 	}
 
 	@Override
-	public UserDeleteResponseDto delete(Long id) {
+	public MemberDeleteResponseDto delete(Long id) {
 		Member member = memberRepository.findById(id)
 			.orElseThrow(() -> new BusinessException("존재하지 않는 회원입니다.", ErrorCode.NOT_FOUND_RESOURCE));
 
 		member.setDeletedAt(LocalDateTime.now());
+		memberRepository.save(member);
 
-		return UserDeleteResponseDto.builder()
+		return MemberDeleteResponseDto.builder()
 			.id(id)
 			.build();
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/util/BaseTimeEntity.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/util/BaseTimeEntity.java
@@ -20,6 +20,4 @@ public abstract class BaseTimeEntity {
 	@LastModifiedDate
 	@Column(nullable = false)
 	private LocalDateTime updatedAt;
-
-	private LocalDateTime deletedAt;
 }

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
 
@@ -31,7 +31,7 @@ class UserControllerTest {
 	@WithMockUser(username = "이진우", roles = "USER")
 	void deleteMember() throws Exception {
 		// given
-		UserDeleteResponseDto userDeleteResponseDto = UserDeleteResponseDto.builder()
+		MemberDeleteResponseDto userDeleteResponseDto = MemberDeleteResponseDto.builder()
 			.id(1L)
 			.build();
 

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -1,0 +1,49 @@
+package org.swmaestro.repl.gifthub.auth.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.swmaestro.repl.gifthub.auth.dto.UserDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.service.MemberService;
+import org.swmaestro.repl.gifthub.util.JwtProvider;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private MemberService memberService;
+
+	@MockBean
+	private JwtProvider jwtProvider;
+
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void deleteMember() throws Exception {
+		// given
+		UserDeleteResponseDto userDeleteResponseDto = UserDeleteResponseDto.builder()
+			.id(1L)
+			.build();
+
+		// when
+		when(jwtProvider.resolveToken(any())).thenReturn("my_awesome_access_token");
+		when(jwtProvider.getUsername(anyString())).thenReturn("이진우");
+		when(memberService.delete(1L)).thenReturn(userDeleteResponseDto);
+
+		// then
+		mockMvc.perform(delete("/users/1")
+				.header("Authorization", "Bearer my_awesome_access_token"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(1L));
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### 작업사항

- BaseEntity의 deletedAt 필드 삭제 및 Member Entity에 deleteAt 필드 추가
  - 사유 : 기존 Member Entity는 BaseEntity를 상속받는데, `@Setter` 어노테이션을 통해 생성된 setter 메서드(soft-delete를 위해 사용)로는 BaseEntity에 상속받은 필드에 대해 setter 메서드를 만들어주지 않음
- MemberDeleteResponseDto 구현
- MemberService - delete 메서드 구현
- MemberControllerTest - delete API test 코드 구현
- MemberController - delete API 구현

### 화면캡처(선택)

### 의문점(선택) 