### PR TITLE
fix/GH-156-voucher-list-response

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -65,7 +65,7 @@ public class VoucherController {
 
 	@GetMapping
 	@Operation(summary = "Voucher 목록 조회 메서드", description = "클라이언트에서 요청한 사용자 별 기프티콘 목록 정보를 조회하기 위한 메서드입니다.")
-	public List<VoucherReadResponseDto> listVoucher(HttpServletRequest request) {
+	public List<Long> listVoucher(HttpServletRequest request) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
 		return voucherService.list(username);
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -78,16 +78,16 @@ public class VoucherService {
 	/*
 	사용자 별 기프티콘 목록 조회 메서드
 	 */
-	public List<VoucherReadResponseDto> list(String username) {
+	public List<Long> list(String username) {
 		List<Voucher> vouchers = voucherRepository.findAllByMemberUsername(username);
 		if (vouchers == null) {
 			throw new BusinessException("존재하지 않는 사용자 입니다.", ErrorCode.NOT_FOUND_RESOURCE);
 		}
-		List<VoucherReadResponseDto> voucherReadResponseDtos = new ArrayList<>();
+		List<Long> voucherIdList = new ArrayList<>();
 		for (Voucher voucher : vouchers) {
-			voucherReadResponseDtos.add(mapToDto(voucher));
+			voucherIdList.add(voucher.getId());
 		}
-		return voucherReadResponseDtos;
+		return voucherIdList;
 	}
 
 	/*

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -102,22 +102,13 @@ class VoucherControllerTest {
 		String accessToken = "my_awesome_access_token";
 		String username = "이진우";
 
-		List<VoucherReadResponseDto> voucherReadResponseDtos = new ArrayList<>();
-		voucherReadResponseDtos.add(VoucherReadResponseDto.builder()
-				.id(1L)
-				.barcode("012345678910")
-				.expiresAt("2023-06-15")
-				.build());
-
-		voucherReadResponseDtos.add(VoucherReadResponseDto.builder()
-				.id(2L)
-				.barcode("012345678911")
-				.expiresAt("2023-06-16")
-				.build());
+		List<Long> voucherIdList = new ArrayList<>();
+		voucherIdList.add(1L);
+		voucherIdList.add(2L);
 
 		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
 		when(jwtProvider.getUsername(anyString())).thenReturn(username);
-		when(voucherService.list(username)).thenReturn(voucherReadResponseDtos);
+		when(voucherService.list(username)).thenReturn(voucherIdList);
 
 		mockMvc.perform(get("/vouchers")
 						.header("Authorization", "Bearer " + accessToken))


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
변경된 API 명세에 따라 `voucher` 목록 조회 API를 수정해야 했습니다.
### Problem Solving
<!-- 해결 방법 -->
<img width="420" alt="스크린샷 2023-08-01 오후 1 23 43" src="https://github.com/SWM-REPL/gifthub-was/assets/62206617/fe475842-e43e-44fb-99de-bd0b2f5e33c0">

명세에 따라 `voucherId` 만 반환하도록 수정하였습니다. 

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
현재 `accessToken`에 내포된 `username`을 이용해 사용자가 소유하고 있는 기프티콘 목록들을 조회하고 있습니다.
