### PR TITLE
fix/GH-155-voucher-read-response

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandController.java
@@ -1,0 +1,29 @@
+package org.swmaestro.repl.gifthub.vouchers.controller;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
+import org.swmaestro.repl.gifthub.vouchers.service.BrandService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/brand")
+@RequiredArgsConstructor
+@Tag(name = "Brand", description = "브랜드 관련 API")
+public class BrandController {
+	private final BrandService brandService;
+
+	@GetMapping("/{brandId}")
+	@Operation(summary = "브랜드 상세 조회 메서드", description = "클라이언트에서 요청한 브랜드 상세 정보를 조회하기 위한 메서드입니다. 응답으로 brand-entity를 반환합니다.")
+	public Brand readBrand(@PathVariable Long brandId) throws IOException {
+		return brandService.readById(brandId);
+	}
+}
+

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductController.java
@@ -1,0 +1,28 @@
+package org.swmaestro.repl.gifthub.vouchers.controller;
+
+import java.io.IOException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.swmaestro.repl.gifthub.vouchers.dto.ProductReadResponseDto;
+import org.swmaestro.repl.gifthub.vouchers.service.ProductService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/products")
+@RequiredArgsConstructor
+@Tag(name = "Products", description = "상품 관련 API")
+public class ProductController {
+	private final ProductService productService;
+
+	@GetMapping("/{productId}")
+	@Operation(summary = "상품 상세 조회 메서드", description = "클라이언트에서 요청한 상품 상세 정보를 조회하기 위한 메서드입니다. 응답으로 product-response-dto를 반환합니다.")
+	public ProductReadResponseDto readProduct(@PathVariable Long productId) throws IOException {
+		return productService.readById(productId);
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
@@ -1,0 +1,35 @@
+package org.swmaestro.repl.gifthub.vouchers.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ProductReadResponseDto {
+	private Long id;
+	private Long brand_id;
+	private String name;
+	private String description;
+	private int isReusable;
+	private int price;
+	private String imageUrl;
+
+	@Builder
+	public ProductReadResponseDto(Long id, Long brand_id, String name, String description, int isReusable, int price, String imageUrl) {
+		this.id = id;
+		this.brand_id = brand_id;
+		this.name = name;
+		this.description = description;
+		this.isReusable = isReusable;
+		this.price = price;
+		this.imageUrl = imageUrl;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ProductReadResponseDto {
 	private Long id;
-	private Long brand_id;
+	private Long brandId;
 	private String name;
 	private String description;
 	private int isReusable;
@@ -23,9 +23,9 @@ public class ProductReadResponseDto {
 	private String imageUrl;
 
 	@Builder
-	public ProductReadResponseDto(Long id, Long brand_id, String name, String description, int isReusable, int price, String imageUrl) {
+	public ProductReadResponseDto(Long id, Long brandId, String name, String description, int isReusable, int price, String imageUrl) {
 		this.id = id;
-		this.brand_id = brand_id;
+		this.brandId = brandId;
 		this.name = name;
 		this.description = description;
 		this.isReusable = isReusable;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class VoucherReadResponseDto {
 	private Long id;
-	private Long product_id;
+	private Long productId;
 	private String barcode;
 	private String expiresAt;
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
@@ -2,8 +2,13 @@ package org.swmaestro.repl.gifthub.vouchers.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import lombok.*;
-import org.swmaestro.repl.gifthub.vouchers.entity.Product;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @Builder
@@ -13,8 +18,7 @@ import org.swmaestro.repl.gifthub.vouchers.entity.Product;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class VoucherReadResponseDto {
 	private Long id;
+	private Long product_id;
 	private String barcode;
 	private String expiresAt;
-	private Product product;
-	private String username;
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Brand.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Brand.java
@@ -6,13 +6,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Brand {
 	@Id
@@ -24,5 +23,12 @@ public class Brand {
 
 	@Column(length = 200, nullable = false)
 	private String imageUrl;
+
+	@Builder
+	public Brand(Long id, String name, String imageUrl) {
+		this.id = id;
+		this.name = name;
+		this.imageUrl = imageUrl;
+	}
 }
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
@@ -1,6 +1,10 @@
 package org.swmaestro.repl.gifthub.vouchers.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
+import org.swmaestro.repl.gifthub.exception.ErrorCode;
 import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
 import org.swmaestro.repl.gifthub.vouchers.repository.BrandRepository;
 
@@ -13,5 +17,13 @@ public class BrandService {
 
 	public Brand read(String brandName) {
 		return brandRepository.findByName(brandName);
+	}
+
+	public Brand readById(Long id) {
+		Optional<Brand> brand = brandRepository.findById(id);
+		if (brand.isEmpty()) {
+			throw new BusinessException("존재하지 않는 브랜드 입니다.", ErrorCode.NOT_FOUND_RESOURCE);
+		}
+		return brand.get();
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
@@ -1,6 +1,11 @@
 package org.swmaestro.repl.gifthub.vouchers.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
+import org.swmaestro.repl.gifthub.exception.ErrorCode;
+import org.swmaestro.repl.gifthub.vouchers.dto.ProductReadResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.entity.Product;
 import org.swmaestro.repl.gifthub.vouchers.repository.ProductRepository;
 
@@ -13,5 +18,27 @@ public class ProductService {
 
 	public Product read(String productName) {
 		return productRepository.findByName(productName);
+	}
+
+	public ProductReadResponseDto readById(Long id) {
+		Optional<Product> product = productRepository.findById(id);
+		if (product.isEmpty()) {
+			throw new BusinessException("존재하지 않는 상품 입니다.", ErrorCode.NOT_FOUND_RESOURCE);
+		}
+		ProductReadResponseDto productReadResponseDto = mapToDto(product.get());
+		return productReadResponseDto;
+	}
+
+	public ProductReadResponseDto mapToDto(Product product) {
+		ProductReadResponseDto productReadResponseDto = ProductReadResponseDto.builder()
+				.id(product.getId())
+				.brand_id(product.getBrand().getId())
+				.name(product.getName())
+				.description(product.getDescription())
+				.isReusable(product.getIsReusable())
+				.price(product.getPrice())
+				.imageUrl(product.getImageUrl())
+				.build();
+		return productReadResponseDto;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
@@ -32,7 +32,7 @@ public class ProductService {
 	public ProductReadResponseDto mapToDto(Product product) {
 		ProductReadResponseDto productReadResponseDto = ProductReadResponseDto.builder()
 				.id(product.getId())
-				.brand_id(product.getBrand().getId())
+				.brandId(product.getBrand().getId())
 				.name(product.getName())
 				.description(product.getDescription())
 				.isReusable(product.getIsReusable())

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -170,10 +170,9 @@ public class VoucherService {
 	public VoucherReadResponseDto mapToDto(Voucher voucher) {
 		VoucherReadResponseDto voucherReadResponseDto = VoucherReadResponseDto.builder()
 				.id(voucher.getId())
+				.product_id(voucher.getProduct().getId())
 				.barcode(voucher.getBarcode())
 				.expiresAt(voucher.getExpiresAt().toString())
-				.product(voucher.getProduct())
-				.username(voucher.getMember().getUsername())
 				.build();
 		return voucherReadResponseDto;
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -170,7 +170,7 @@ public class VoucherService {
 	public VoucherReadResponseDto mapToDto(Voucher voucher) {
 		VoucherReadResponseDto voucherReadResponseDto = VoucherReadResponseDto.builder()
 				.id(voucher.getId())
-				.product_id(voucher.getProduct().getId())
+				.productId(voucher.getProduct().getId())
 				.barcode(voucher.getBarcode())
 				.expiresAt(voucher.getExpiresAt().toString())
 				.build();

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandControllerTest.java
@@ -1,0 +1,53 @@
+package org.swmaestro.repl.gifthub.vouchers.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
+import org.swmaestro.repl.gifthub.vouchers.service.BrandService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BrandControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private BrandService brandService;
+
+	/**
+	 * 브랜드 상세 조회 테스트
+	 */
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void readBrand() throws Exception {
+		// given
+		Brand brand = Brand.builder()
+				.id(1L)
+				.name("스타벅스")
+				.imageUrl("image_url_1")
+				.build();
+		// when
+		when(brandService.readById(1L)).thenReturn(brand);
+		// then
+		mockMvc.perform(get("/brand/1")
+						.header("Authorization", "Bearer my_awesome_access_token")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(brand)))
+				.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductControllerTest.java
@@ -38,7 +38,7 @@ public class ProductControllerTest {
 		// given
 		ProductReadResponseDto productReadResponseDto = ProductReadResponseDto.builder()
 				.id(1L)
-				.brand_id(1L)
+				.brandId(1L)
 				.name("아이스 아메리카노")
 				.price(4500)
 				.imageUrl("https://스타벅스_아이스아메리카노T.png")

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/ProductControllerTest.java
@@ -1,0 +1,56 @@
+package org.swmaestro.repl.gifthub.vouchers.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.swmaestro.repl.gifthub.vouchers.dto.ProductReadResponseDto;
+import org.swmaestro.repl.gifthub.vouchers.service.ProductService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ProductControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private ProductService productService;
+
+	/**
+	 * 상품 상세 조회 테스트
+	 */
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void readProduct() throws Exception {
+		// given
+		ProductReadResponseDto productReadResponseDto = ProductReadResponseDto.builder()
+				.id(1L)
+				.brand_id(1L)
+				.name("아이스 아메리카노")
+				.price(4500)
+				.imageUrl("https://스타벅스_아이스아메리카노T.png")
+				.build();
+		// when
+		when(productService.readById(1L)).thenReturn(productReadResponseDto);
+		// then
+		mockMvc.perform(get("/products/1")
+						.header("Authorization", "Bearer my_awesome_access_token")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(productReadResponseDto)))
+				.andExpect(status().isOk());
+	}
+
+}

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -82,7 +82,7 @@ class VoucherControllerTest {
 		String username = "user11";
 		VoucherReadResponseDto voucherReadResponseDto = VoucherReadResponseDto.builder()
 				.id(1L)
-				.product_id(1L)
+				.productId(1L)
 				.barcode("012345678910")
 				.expiresAt("2023-06-15")
 				.build();

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -1,6 +1,5 @@
 package org.swmaestro.repl.gifthub.vouchers.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -75,22 +74,29 @@ class VoucherControllerTest {
 	기프티콘 상세 조회 테스트
 	 */
 	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
 	void readVoucherTest() throws Exception {
 		// given
 		Long voucherId = 1L;
+		String accessToken = "my_awesome_access_token";
 		String username = "user11";
 		VoucherReadResponseDto voucherReadResponseDto = VoucherReadResponseDto.builder()
 				.id(1L)
+				.product_id(1L)
 				.barcode("012345678910")
 				.expiresAt("2023-06-15")
 				.build();
-
-		when(voucherService.read(voucherId, username)).thenReturn(voucherReadResponseDto);
 		//when
-		VoucherReadResponseDto result = voucherService.read(voucherId, username);
+		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
+		when(jwtProvider.getUsername(anyString())).thenReturn(username);
+		when(voucherService.read(voucherId, username)).thenReturn(voucherReadResponseDto);
 
 		// then
-		assertEquals(voucherId, result.getId());
+		mockMvc.perform(get("/vouchers/1")
+						.header("Authorization", "Bearer my_awesome_access_token")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(voucherReadResponseDto)))
+				.andExpect(status().isOk());
 	}
 
 	/*


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
변경된 API 명세에 따라 `voucher` 상세 조회 응답 값을 변환해야 했습니다.
또한 새롭게 `product`와 `brand`를 상세 조회하는 API를 구현해야 했습니다.

### Problem Solving
<!-- 해결 방법 -->
기존의 `VoucherReadResponseDto`의 `product` 필드를 삭제하고 `productId`를 추가하였습니다.
또한 `product`를 조회할 때는 `ProductReadResponseDto`에 `brand`가 아니라 `brandId`를 응답하도록 했습니다.


### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
❗️기존에 `ProductService` , `BrandService`에 `read` 메서드가 존재했기 때문에 `readById` 라는 메서드로 명명했습니다.
❗️`brand`를 조회할 때는 `brand` 엔티티를 그대로 응답하게 구현되어 있습니다
