### PR TITLE
fix/GH-177-voucher-save

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Brand.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Brand.java
@@ -21,7 +21,7 @@ public class Brand {
 	@Column(length = 40, nullable = false, unique = true)
 	private String name;
 
-	@Column(length = 200, nullable = false)
+	@Column(length = 200)
 	private String imageUrl;
 
 	@Builder

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
@@ -1,5 +1,7 @@
 package org.swmaestro.repl.gifthub.vouchers.entity;
 
+import org.hibernate.annotations.ColumnDefault;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,6 +33,7 @@ public class Product {
 	private String description;
 
 	@Column(columnDefinition = "TINYINT", nullable = false)
+	@ColumnDefault("0")
 	private int isReusable;
 
 	@Column(nullable = false)

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
@@ -26,4 +26,12 @@ public class BrandService {
 		}
 		return brand.get();
 	}
+
+	public Brand save(String brandName) {
+		Brand brand = Brand.builder()
+				.name(brandName)
+				.build();
+
+		return brandRepository.save(brand);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.exception.ErrorCode;
 import org.swmaestro.repl.gifthub.vouchers.dto.ProductReadResponseDto;
+import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
 import org.swmaestro.repl.gifthub.vouchers.entity.Product;
 import org.swmaestro.repl.gifthub.vouchers.repository.ProductRepository;
 
@@ -27,6 +28,23 @@ public class ProductService {
 		}
 		ProductReadResponseDto productReadResponseDto = mapToDto(product.get());
 		return productReadResponseDto;
+	}
+
+	public Product save(String productName) {
+		Product product = Product.builder()
+				.name(productName)
+				.build();
+
+		return productRepository.save(product);
+	}
+
+	public Product save(String productName, Brand brand) {
+		Product product = Product.builder()
+				.name(productName)
+				.brand(brand)
+				.build();
+
+		return productRepository.save(product);
 	}
 
 	public ProductReadResponseDto mapToDto(Product product) {

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
@@ -30,14 +30,6 @@ public class ProductService {
 		return productReadResponseDto;
 	}
 
-	public Product save(String productName) {
-		Product product = Product.builder()
-				.name(productName)
-				.build();
-
-		return productRepository.save(product);
-	}
-
 	public Product save(String productName, Brand brand) {
 		Product product = Product.builder()
 				.name(productName)

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -50,6 +50,7 @@ public class VoucherService {
 
 		if (brand == null) {
 			brand = brandService.save(voucherSaveRequestDto.getBrandName());
+			product = productService.save(voucherSaveRequestDto.getProductName(), brand);
 		}
 		if (product == null) {
 			product = productService.save(voucherSaveRequestDto.getProductName(), brand);

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -19,6 +19,8 @@ import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseResponseDto;
+import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
+import org.swmaestro.repl.gifthub.vouchers.entity.Product;
 import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
 import org.swmaestro.repl.gifthub.vouchers.entity.VoucherUsageHistory;
 import org.swmaestro.repl.gifthub.vouchers.repository.VoucherRepository;
@@ -43,9 +45,19 @@ public class VoucherService {
 	 */
 	public VoucherSaveResponseDto save(String username, VoucherSaveRequestDto voucherSaveRequestDto) throws
 			IOException {
+		Brand brand = brandService.read(voucherSaveRequestDto.getBrandName());
+		Product product = productService.read(voucherSaveRequestDto.getProductName());
+
+		if (brand == null) {
+			brand = brandService.save(voucherSaveRequestDto.getBrandName());
+		}
+		if (product == null) {
+			product = productService.save(voucherSaveRequestDto.getProductName(), brand);
+		}
+
 		Voucher voucher = Voucher.builder()
-				.brand(brandService.read(voucherSaveRequestDto.getBrandName()))
-				.product(productService.read(voucherSaveRequestDto.getProductName()))
+				.brand(brand)
+				.product(product)
 				.barcode(voucherSaveRequestDto.getBarcode())
 				.expiresAt(DateConverter.stringToLocalDate(voucherSaveRequestDto.getExpiresAt()))
 				.imageUrl(storageService.getBucketAddress(voucherDirName) + voucherSaveRequestDto.getImageUrl())


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
기프티콘 등록 시 DB에 존재하지 않는 브랜드 및 상품을 입력하였을 경우 이에 대한 오류를 해결하기 위해 구현

### Problem Solving
<!-- 해결 방법 -->
- 브랜드명이 존재하지 않았을 경우
  - 브랜드 생성
  - 브랜드에 따른 상품 생성
- 상품이 존재하지 않을 경우
  - 브랜드에 따른 상품 생성

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- 기존 `Brand` Entity에 imageUrl의 not-null 옵션을 제거하였음
- `Product` Entity에 재사용(isResuable) 컬럼의 초기 값을 0(기본적으로 상품형 기프티콘)으로 지정하였음 