### PR TITLE
feat/GH-179-user-read-api

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -1,12 +1,14 @@
 package org.swmaestro.repl.gifthub.auth.controller;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
@@ -39,4 +41,9 @@ public class UserController {
 		return memberService.update(username, userId, memberUpdateRequestDto);
 	}
 
+	@GetMapping("/{userId}")
+	@Operation(summary = "User 정보 조회 메서드", description = "클라이언트에서 요청한 사용자 정보를 조회하기 위한 메서드입니다. 응답으로 회원 id와 nickname을 반환합니다.")
+	public MemberReadResponseDto readMember(@PathVariable Long userId) {
+		return memberService.read(userId);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberReadResponseDto.java
@@ -1,0 +1,20 @@
+package org.swmaestro.repl.gifthub.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class MemberReadResponseDto {
+	private Long id;
+	private String nickname;
+
+	@Builder
+	public MemberReadResponseDto(Long id, String nickname) {
+		this.id = id;
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
@@ -3,6 +3,7 @@ package org.swmaestro.repl.gifthub.auth.service;
 import java.util.List;
 
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
@@ -19,6 +20,8 @@ public interface MemberService {
 	Member passwordEncryption(Member member);
 
 	Member read(String username);
+
+	MemberReadResponseDto read(Long id);
 
 	int count();
 

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
@@ -2,12 +2,14 @@ package org.swmaestro.repl.gifthub.auth.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
@@ -90,6 +92,18 @@ public class MemberServiceImpl implements MemberService {
 			return null;
 		}
 		return member;
+	}
+
+	@Override
+	public MemberReadResponseDto read(Long id) {
+		Optional<Member> member = memberRepository.findById(id);
+		if (member.isEmpty()) {
+			throw new BusinessException("존재하지 않는 회원입니다.", ErrorCode.NOT_FOUND_RESOURCE);
+		}
+		return MemberReadResponseDto.builder()
+				.id(member.get().getId())
+				.nickname(member.get().getNickname())
+				.build();
 	}
 
 	@Override

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -99,8 +99,6 @@ class UserControllerTest {
 		//then
 		mockMvc.perform(get("/users/1")
 						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.id").value(1L))
-				.andExpect(jsonPath("$.nickname").value("이진우"));
+				.andExpect(status().isOk());
 	}
 }

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
@@ -80,5 +81,26 @@ class UserControllerTest {
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(memberUpdateResponseDto)))
 				.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void readMember() throws Exception {
+		//given
+		String username = "이진우";
+		Long userId = 1L;
+		MemberReadResponseDto memberReadResponseDto = MemberReadResponseDto.builder()
+				.id(1L)
+				.nickname("이진우")
+				.build();
+		//when
+		when(memberService.read(anyLong())).thenReturn(memberReadResponseDto);
+
+		//then
+		mockMvc.perform(get("/users/1")
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(1L))
+				.andExpect(jsonPath("$.nickname").value("이진우"));
 	}
 }


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
사용자의 닉네임이 필요하다는 요청이 있어서 사용자의 정보(닉네임)을 반환하는 API를 만들어야 했습니다.

### Problem Solving
<!-- 해결 방법 -->
`users/{userId}` 엔드포인트에 get요청 시 회원 id와 nickname정보를 갖고 있는 `MemberReadResponseDto` 을 응답하는 API를 구현하였습니다.

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
기존의 `username`으로 회원을 조회하는 메소드가 있어서 **메소드 오버로딩**을 이용해 `id`로 회원을 조회하는 메소드를 작성하였습니다. 