### PR TITLE
Remove unique option to product name

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/brand")
+@RequestMapping("/brands")
 @RequiredArgsConstructor
 @Tag(name = "Brand", description = "브랜드 관련 API")
 public class BrandController {

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -40,7 +40,7 @@ public class VoucherController {
 	private final StorageService storageService;
 	private final JwtProvider jwtProvider;
 
-	@PostMapping("/image")
+	@PostMapping("/images")
 	@Operation(summary = "Voucher 이미지 등록 메서드", description = "클라이언트에서 요청한 기프티콘 이미지를 Amazon S3에 저장하기 위한 메서드입니다.")
 	public ResponseEntity<Message> saveVoucherImage(@RequestPart("image_file") MultipartFile imageFile) throws IOException {
 		return new ResponseEntity<>(

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
@@ -26,7 +26,7 @@ public class Product {
 	@JoinColumn(name = "brand_id", nullable = false)
 	private Brand brand;
 
-	@Column(length = 100, nullable = false, unique = true)
+	@Column(length = 100, nullable = false)
 	private String name;
 
 	@Column(columnDefinition = "TEXT")

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/BrandControllerTest.java
@@ -44,7 +44,7 @@ public class BrandControllerTest {
 		// when
 		when(brandService.readById(1L)).thenReturn(brand);
 		// then
-		mockMvc.perform(get("/brand/1")
+		mockMvc.perform(get("/brands/1")
 						.header("Authorization", "Bearer my_awesome_access_token")
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(objectMapper.writeValueAsString(brand)))


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
동일한 상품명이더라도 브랜드가 다르다면 저장이 되도록 해야함

### Problem Solving
<!-- 해결 방법 -->
기존 Product Entity의 name 컬럼에 unique 옵션 삭제

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
- ex) `CU의 바나나우유`와 `GS25의 바나나우유`는 다른 기프티콘이지만 동일한 이름의 상품임
- 추가적으로 이태우 멘토님께서 말씀하신대로 API Path가 단수인 것들을 복수로 변경하였습니다.
