### PR TITLE
Save change of balance to voucher table and Return product price when voucher is used

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -125,7 +125,7 @@ public class VoucherController {
 		return new ResponseEntity<>(
 				Message.builder()
 						.status(StatusEnum.OK)
-						.message("기프티콘 목록이 성공적으로 조회되었습니다!")
+						.message("기프티콘이 성공적으로 사용되었습니다!")
 						.data(voucherService.use(username, voucherId, voucherUseRequestDto))
 						.build(),
 				new HttpJsonHeaders(),

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
@@ -21,4 +21,6 @@ public class VoucherReadResponseDto {
 	private Long productId;
 	private String barcode;
 	private String expiresAt;
+	private Integer price;
+	private int balance;
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherReadResponseDto.java
@@ -21,6 +21,6 @@ public class VoucherReadResponseDto {
 	private Long productId;
 	private String barcode;
 	private String expiresAt;
-	private Integer price;
+	private int price;
 	private int balance;
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseRequestDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseRequestDto.java
@@ -2,23 +2,21 @@ package org.swmaestro.repl.gifthub.vouchers.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class VoucherUseRequestDto {
-	private Long id;
-	private int amount;
+	private Integer amount;
 	private String place;
 
 	@Builder
-	public VoucherUseRequestDto(Long id, int amount, String place) {
-		this.id = id;
+	public VoucherUseRequestDto(Integer amount, String place) {
 		this.amount = amount;
 		this.place = place;
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseResponseDto.java
@@ -2,6 +2,7 @@ package org.swmaestro.repl.gifthub.vouchers.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,11 +15,13 @@ public class VoucherUseResponseDto {
 	private Long usageId;
 	private Long voucherId;
 	private int balance;
+	private int price;
 
 	@Builder
-	public VoucherUseResponseDto(Long usageId, Long voucherId, int balance) {
+	public VoucherUseResponseDto(Long usageId, Long voucherId, int balance, int price) {
 		this.usageId = usageId;
 		this.voucherId = voucherId;
 		this.balance = balance;
+		this.price = price;
 	}
 }

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -161,7 +161,6 @@ class VoucherControllerTest {
 		// given
 		Long voucherId = 1L;
 		VoucherUseRequestDto voucherUseRequestDto = VoucherUseRequestDto.builder()
-				.id(1L)
 				.amount(5000)
 				.place("스타벅스 아남타워점")
 				.build();
@@ -170,6 +169,7 @@ class VoucherControllerTest {
 				.usageId(1L)
 				.voucherId(1L)
 				.balance(20000)
+				.price(25000)
 				.build();
 
 		// when


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
클라이언트에서 요청하여 기프티콘 사용 시, voucher 테이블의 `balance`가 수정되고자 하였습니다.
`product price`(정가)를 `VoucherReadResponseDto`로 전달하여 클라이언트에서 확인이 가능하고자 하였습니다.
### Problem Solving
<!-- 해결 방법 -->
`RequestBody`로 `amount`나 `place`를 안보낸 경우 예외처리 로직을 추가했습니다.
기프티콘 사용시 voucher 테이블의 `balance`가 차감도록 로직을 수정하였습니다. 
`voucherReadDto`에 `product`의 `price` 필드를 추가하였습니다.

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
❗️`VoucherUseRequestDto`의 `amount`가 `int`형인 경우 null 처리가 안되고 자동으로 0으로 초기화 되기 때문에 예외처리를 위해 `Integer`형으로 선언하였습니다.
