### PR TITLE
Add query-string 'member_id' to read voucher-list API

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -65,7 +65,7 @@ public class UserController {
 		return new ResponseEntity<>(
 				Message.builder()
 						.status(StatusEnum.OK)
-						.message("성공적으로 조호되었습니다!")
+						.message("성공적으로 조회되었습니다!")
 						.data(memberService.read(userId))
 						.build(),
 				new HttpJsonHeaders(),

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/MemberReadResponseDto.java
@@ -11,10 +11,12 @@ import lombok.Getter;
 public class MemberReadResponseDto {
 	private Long id;
 	private String nickname;
+	private String username;
 
 	@Builder
-	public MemberReadResponseDto(Long id, String nickname) {
+	public MemberReadResponseDto(Long id, String nickname, String username) {
 		this.id = id;
 		this.nickname = nickname;
+		this.username = username;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberServiceImpl.java
@@ -106,6 +106,7 @@ public class MemberServiceImpl implements MemberService {
 		return MemberReadResponseDto.builder()
 				.id(member.get().getId())
 				.nickname(member.get().getNickname())
+				.username(member.get().getUsername())
 				.build();
 	}
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -90,7 +90,7 @@ public class VoucherController {
 
 	@GetMapping
 	@Operation(summary = "Voucher 목록 조회 메서드", description = "클라이언트에서 요청한 사용자 별 기프티콘 목록 정보를 조회하기 위한 메서드입니다.")
-	public ResponseEntity<Message> listVoucher(HttpServletRequest request, @RequestParam("member_id") Long memberId) {
+	public ResponseEntity<Message> listVoucher(HttpServletRequest request, @RequestParam(value = "member_id", required = true) Long memberId) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
 		return new ResponseEntity<>(
 				Message.builder()

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -89,13 +90,13 @@ public class VoucherController {
 
 	@GetMapping
 	@Operation(summary = "Voucher 목록 조회 메서드", description = "클라이언트에서 요청한 사용자 별 기프티콘 목록 정보를 조회하기 위한 메서드입니다.")
-	public ResponseEntity<Message> listVoucher(HttpServletRequest request) {
+	public ResponseEntity<Message> listVoucher(HttpServletRequest request, @RequestParam("member_id") Long memberId) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
 		return new ResponseEntity<>(
 				Message.builder()
 						.status(StatusEnum.OK)
 						.message("기프티콘 목록이 성공적으로 조회되었습니다!")
-						.data(voucherService.list(username))
+						.data(voucherService.list(memberId, username))
 						.build(),
 				new HttpJsonHeaders(),
 				HttpStatus.OK

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/repository/VoucherRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/repository/VoucherRepository.java
@@ -1,11 +1,13 @@
 package org.swmaestro.repl.gifthub.vouchers.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
 
-import java.util.List;
-
 public interface VoucherRepository extends JpaRepository<Voucher, Long> {
 	List<Voucher> findAllByMemberUsername(String username);
+
+	List<Voucher> findAllByMemberId(Long memberId);
 
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -95,7 +95,27 @@ public class VoucherService {
 	}
 
 	/*
-	사용자 별 기프티콘 목록 조회 메서드
+	사용자 별 기프티콘 목록 조회 메서드(userId로 조회, username으로 권한 대조)
+	 */
+	public List<Long> list(Long userId, String username) {
+		if (!memberService.read(userId).getUsername().equals(username)) {
+			throw new BusinessException("상품권을 조회할 권한이 없습니다.", StatusEnum.NOT_FOUND);
+		}
+
+		List<Voucher> vouchers = voucherRepository.findAllByMemberId(userId);
+		if (vouchers == null) {
+			throw new BusinessException("존재하지 않는 회원입니다.", StatusEnum.NOT_FOUND);
+		}
+
+		List<Long> voucherIdList = new ArrayList<>();
+		for (Voucher voucher : vouchers) {
+			voucherIdList.add(voucher.getId());
+		}
+		return voucherIdList;
+	}
+
+	/*
+	사용자 별 기프티콘 목록 조회 메서드(username으로 조회)
 	 */
 	public List<Long> list(String username) {
 		List<Voucher> vouchers = voucherRepository.findAllByMemberUsername(username);
@@ -180,7 +200,7 @@ public class VoucherService {
 
 		voucher.get().setBalance(remainingBalance - requestedAmount);
 		voucherRepository.save(voucher.get());
-		
+
 		return VoucherUseResponseDto.builder()
 				.usageId(voucherUsageHistory.getId())
 				.voucherId(voucherId)

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -103,10 +103,6 @@ public class VoucherService {
 		}
 
 		List<Voucher> vouchers = voucherRepository.findAllByMemberId(userId);
-		if (vouchers == null) {
-			throw new BusinessException("존재하지 않는 회원입니다.", StatusEnum.NOT_FOUND);
-		}
-
 		List<Long> voucherIdList = new ArrayList<>();
 		for (Voucher voucher : vouchers) {
 			voucherIdList.add(voucher.getId());
@@ -119,9 +115,6 @@ public class VoucherService {
 	 */
 	public List<Long> list(String username) {
 		List<Voucher> vouchers = voucherRepository.findAllByMemberUsername(username);
-		if (vouchers == null) {
-			throw new BusinessException("존재하지 않는 사용자 입니다.", StatusEnum.NOT_FOUND);
-		}
 		List<Long> voucherIdList = new ArrayList<>();
 		for (Voucher voucher : vouchers) {
 			voucherIdList.add(voucher.getId());

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -106,6 +106,7 @@ class VoucherControllerTest {
 	@WithMockUser(username = "이진우", roles = "USER")
 	void listVoucherTest() throws Exception {
 		String accessToken = "my_awesome_access_token";
+		Long memberId = 1L;
 		String username = "이진우";
 
 		List<Long> voucherIdList = new ArrayList<>();
@@ -114,9 +115,9 @@ class VoucherControllerTest {
 
 		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
 		when(jwtProvider.getUsername(anyString())).thenReturn(username);
-		when(voucherService.list(username)).thenReturn(voucherIdList);
+		when(voucherService.list(memberId, username)).thenReturn(voucherIdList);
 
-		mockMvc.perform(get("/vouchers")
+		mockMvc.perform(get("/vouchers?member_id=" + memberId)
 						.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk());
 	}


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

프론트엔드에서 상품권 목록 조회 시 쿼리 스트링을 통해 사용자 아이디를 입력받자는 의견을 제시하였음

### Problem Solving

Voucher List 조회 API에 `?member_id=[member_id]`를 입력하면 해당 사용자의 기프티콘 목록을 조회하도록 수정하였음

### To Reviewer

- Voucher LIst 조회 시 반드시 member_id 옵션이 필요하도록 구현하였습니다.
- 기존 `MemberReadResponseDto`에 `username`이 존재하지 않아 추가하였습니다.