### PR TITLE
Implement divice-token management logic

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
@@ -1,7 +1,13 @@
 package org.swmaestro.repl.gifthub.auth.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
 
 public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+	Optional<DeviceToken> findByToken(String token);
+
+	Optional<DeviceToken> findByMemberAndToken(Member member, String token);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
@@ -1,5 +1,6 @@
 package org.swmaestro.repl.gifthub.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 	Optional<DeviceToken> findByToken(String token);
 
 	Optional<DeviceToken> findByMemberAndToken(Member member, String token);
+
+	List<DeviceToken> findAllByMember(Member member);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
@@ -7,6 +7,8 @@ import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.repository.DeviceTokenRepository;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
+import org.swmaestro.repl.gifthub.util.StatusEnum;
 
 import lombok.RequiredArgsConstructor;
 
@@ -54,4 +56,19 @@ public class DeviceTokenService {
 		return deviceTokenRepository.findAllByMember(member);
 	}
 
+	/*
+	 * DeviceToken 선택 조회 메서드 (token)
+	 */
+	public DeviceToken read(String token) {
+		return deviceTokenRepository.findByToken(token)
+				.orElseThrow(() -> new BusinessException("존재하지 않는 토큰입니다.", StatusEnum.INTERNAL_SERVER_ERROR));
+	}
+
+	/*
+	 * DeviceToken 선택 조회 메서드 (deviceTokenId)
+	 */
+	public DeviceToken read(Long deviceTokenId) {
+		return deviceTokenRepository.findById(deviceTokenId)
+				.orElseThrow(() -> new BusinessException("존재하지 않는 토큰입니다.", StatusEnum.INTERNAL_SERVER_ERROR));
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
@@ -1,5 +1,7 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
@@ -42,4 +44,14 @@ public class DeviceTokenService {
 
 		return deviceTokenRepository.findByMemberAndToken(member, deviceToken).isPresent();
 	}
+
+	/*
+	 * DeviceToken 전체 조회 메서드
+	 */
+	public List<DeviceToken> list(Long memberId) {
+		MemberReadResponseDto memberDto = memberService.read(memberId);
+		Member member = memberService.read(memberDto.getUsername());
+		return deviceTokenRepository.findAllByMember(member);
+	}
+
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
@@ -71,4 +71,12 @@ public class DeviceTokenService {
 		return deviceTokenRepository.findById(deviceTokenId)
 				.orElseThrow(() -> new BusinessException("존재하지 않는 토큰입니다.", StatusEnum.INTERNAL_SERVER_ERROR));
 	}
+
+	/*
+	 * DeviceToken 삭제 메서드 (token)
+	 */
+	public void delete(String token) {
+		DeviceToken deviceToken = read(token);
+		deviceTokenRepository.delete(deviceToken);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
@@ -1,0 +1,27 @@
+package org.swmaestro.repl.gifthub.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
+import org.swmaestro.repl.gifthub.auth.repository.DeviceTokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+	private final DeviceTokenRepository deviceTokenRepository;
+	private final MemberService memberService;
+
+	/*
+	 * DeviceToken 저장 메서드
+	 */
+	public DeviceToken save(String username, String token) {
+		Member member = memberService.read(username);
+		DeviceToken deviceToken = DeviceToken.builder()
+				.member(member)
+				.token(token)
+				.build();
+		return deviceTokenRepository.save(deviceToken);
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/DeviceTokenService.java
@@ -1,6 +1,7 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
 import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.repository.DeviceTokenRepository;
@@ -23,5 +24,22 @@ public class DeviceTokenService {
 				.token(token)
 				.build();
 		return deviceTokenRepository.save(deviceToken);
+	}
+
+	/*
+	 * DeviceToken 존재 여부 반환 메서드 (토큰만으로)
+	 */
+	public boolean isExist(String deviceToken) {
+		return deviceTokenRepository.findByToken(deviceToken).isPresent();
+	}
+
+	/*
+	 * DeviceToken 존재 여부 반환 메서드 (회원 아이디와 토큰으로)
+	 */
+	public boolean isExist(Long memberId, String deviceToken) {
+		MemberReadResponseDto memberDto = memberService.read(memberId);
+		Member member = memberService.read(memberDto.getUsername());
+
+		return deviceTokenRepository.findByMemberAndToken(member, deviceToken).isPresent();
 	}
 }


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

FCM을 통해 알림 서비스를 구현하기 위해, 사용자의 DeviceToken 관리 필요성 대두

### Problem Solving

- DeviceToken 관리 로직 구현
  - 저장
  - 존재 여부 판별
  - 조회
    - 하나의 회원에 해당하는 전체 토큰 조회
    - 하나의 디바이스 토큰 조회
  - 삭제

### To Reviewer

추후 클라이언트에서 DeviceToken을 주는 로직이 구현될 경우 별도 PR을 통해 DeviceToken 저장 로직을 활용하는 기능을 구현할 예정입니다.
