### PR TITLE
Change type from  NotificationType to String in Notification-Read-Response-Dto

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
@@ -4,12 +4,14 @@ import lombok.Getter;
 
 @Getter
 public enum NotificationType {
-	EXPIRATION(0),     // 유효기간 임박
-	RECOMMENDATION(1);   // 사용 추천
+	EXPIRATION(0, "유효기간 임박 알림"),     // 유효기간 임박
+	RECOMMENDATION(1, "사용 추천 알림");   // 사용 추천
 
 	private final int value;
+	private final String description;
 
-	NotificationType(int value) {
+	NotificationType(int value, String description) {
 		this.value = value;
+		this.description = description;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/dto/NotificationReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/dto/NotificationReadResponseDto.java
@@ -2,8 +2,6 @@ package org.swmaestro.repl.gifthub.notifications.dto;
 
 import java.time.LocalDateTime;
 
-import org.swmaestro.repl.gifthub.notifications.NotificationType;
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -17,13 +15,13 @@ import lombok.NoArgsConstructor;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class NotificationReadResponseDto {
 	private Long id;
-	private NotificationType type;
+	private String type;
 	private String message;
 	private LocalDateTime notifiedAt;
 	private Long voucherId;
 
 	@Builder
-	public NotificationReadResponseDto(Long id, NotificationType type, String message, LocalDateTime notifiedAt, Long voucherId) {
+	public NotificationReadResponseDto(Long id, String type, String message, LocalDateTime notifiedAt, Long voucherId) {
 		this.id = id;
 		this.type = type;
 		this.message = message;

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
@@ -41,7 +41,7 @@ public class NotificationService {
 	public NotificationReadResponseDto mapToDto(Notification notification) {
 		NotificationReadResponseDto notificationReadResponseDto = NotificationReadResponseDto.builder()
 				.id(notification.getId())
-				.type(notification.getType().getValue() == 0 ? "유효기간 임박 알림" : "사용 추천 알림")
+				.type(notification.getType().getDescription())
 				.message(notification.getMessage())
 				.notifiedAt(notification.getCreatedAt())
 				.voucherId(notification.getVoucher().getId())

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
@@ -41,7 +41,7 @@ public class NotificationService {
 	public NotificationReadResponseDto mapToDto(Notification notification) {
 		NotificationReadResponseDto notificationReadResponseDto = NotificationReadResponseDto.builder()
 				.id(notification.getId())
-				.type(notification.getType())
+				.type(notification.getType().getValue() == 0 ? "유효기간 임박 알림" : "사용 추천 알림")
 				.message(notification.getMessage())
 				.notifiedAt(notification.getCreatedAt())
 				.voucherId(notification.getVoucher().getId())

--- a/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.swmaestro.repl.gifthub.notifications.NotificationType;
 import org.swmaestro.repl.gifthub.notifications.dto.NotificationReadResponseDto;
 import org.swmaestro.repl.gifthub.notifications.service.NotificationService;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
@@ -45,7 +44,7 @@ public class NotificationControllerTest {
 		List<NotificationReadResponseDto> notifications = new ArrayList<>();
 		notifications.add(NotificationReadResponseDto.builder()
 				.id(1L)
-				.type(NotificationType.EXPIRATION)
+				.type("유효기간 임박 알림")
 				.message("유효기간이 3일 남았습니다.")
 				.voucherId(1L)
 				.notifiedAt(LocalDateTime.now())
@@ -59,7 +58,7 @@ public class NotificationControllerTest {
 						.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data[0].id").value(1L))
-				.andExpect(jsonPath("$.data[0].type").value(NotificationType.EXPIRATION.name()))
+				.andExpect(jsonPath("$.data[0].type").value("유효기간 임박 알림"))
 				.andExpect(jsonPath("$.data[0].message").value("유효기간이 3일 남았습니다."))
 				.andReturn();
 


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
와이프레임에 맞게 클라이언트에서 notificatio-read-response-dto의 type을 `String` 형식으로의 변경 요청이 있었습니다.

**기존**

```json
{
    "status_code": 200,
    "message": "알림 목록 조회에 성공하였습니다!",
    "data": [
        {
            "id": 3,
            "type": "EXPIRATION",
            "message": "스타벅스에서 사용할 수 있는 기프티콘 기한이 5일 남았습니다.",
            "notified_at": "2023-08-01T13:06:39.440224",
            "voucher_id": 2
        }
    ]
}
```

**수정**
```json
{
    "status_code": 200,
    "message": "알림 목록 조회에 성공하였습니다!",
    "data": [
        {
            "id": 3,
            "type": "유효기간 임박 알림",
            "message": "스타벅스에서 사용할 수 있는 기프티콘 기한이 5일 남았습니다.",
            "notified_at": "2023-08-01T13:06:39.440224",
            "voucher_id": 2
        }
    ]
}
```
### Problem Solving
<!-- 해결 방법 -->
`NotificationService`의 mapToDto 에서 문자열로 매핑해주는 로직을 추가했습니다.
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
❗️현재는 알림 종류가 2가지(위치기반 사용추천 알림은 하지 않으니까 사실상 유효기간 알림 한가지라고 생각합니다.)여서 삼항 연산자로 쉽게 구현할 수 있었지만, 알림 종류가 늘어난다면 고민해봐야할 것 같습니다. 