### PR TITLE
Implement notification read API and Save checked-at

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
@@ -3,6 +3,7 @@ package org.swmaestro.repl.gifthub.notifications.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -32,7 +33,7 @@ public class NotificationController {
 	private final JwtProvider jwtProvider;
 
 	@GetMapping
-	@Operation(summary = "Notification 목록 조회 메서드", description = "클라이언트에서 요청한 알림 목록 정보를 조회하기 위한 메서드입니다. 응답으로 알림 type, message, notified date, 기프티콘 정보를 반환합니다.")
+	@Operation(summary = "Notification 목록 조회 메서드", description = "클라이언트에서 요청한 알림 목록 정보를 조회하기 위한 메서드입니다. 응답으로 알림 type, message, notified date, 기프티콘 정보, 알림 확인 시간을 반환합니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
 			@ApiResponse(responseCode = "400(404)", description = "존재하지 않는 회원"),
@@ -66,6 +67,27 @@ public class NotificationController {
 				Message.builder()
 						.status(StatusEnum.OK)
 						.message("디바이스 토큰 등록에 성공하였습니다!")
+						.build(),
+				new HttpJsonHeaders(),
+				HttpStatus.OK
+		);
+	}
+
+	@GetMapping("/{notificationId}")
+	@Operation(summary = "Notification 상세 조회 메서드", description = "클라이언트에서 요청한 알림 상세 정보를 조회하기 위한 메서드입니다. 응답으로 알림 type, message, notified date, 기프티콘 정보, 기존 알림 확인 시간을 반환합니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "알림 상세 조회 성공"),
+			@ApiResponse(responseCode = "400(404)", description = "존재하지 않는 알림"),
+			@ApiResponse(responseCode = "400(403)", description = "알림 상세 조회 권한 없음"),
+	})
+	public ResponseEntity<Message> readNotification(@RequestHeader("Authorization") String accessToken,
+			@PathVariable Long notificationId) {
+		String username = jwtProvider.getUsername(accessToken.substring(7));
+		return new ResponseEntity<>(
+				Message.builder()
+						.status(StatusEnum.OK)
+						.message("알림 상세 조회에 성공하였습니다!")
+						.data(notificationService.read(notificationId, username))
 						.build(),
 				new HttpJsonHeaders(),
 				HttpStatus.OK

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/dto/NotificationReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/dto/NotificationReadResponseDto.java
@@ -19,13 +19,16 @@ public class NotificationReadResponseDto {
 	private String message;
 	private LocalDateTime notifiedAt;
 	private Long voucherId;
+	private LocalDateTime checkedAt;
 
 	@Builder
-	public NotificationReadResponseDto(Long id, String type, String message, LocalDateTime notifiedAt, Long voucherId) {
+	public NotificationReadResponseDto(Long id, String type, String message, LocalDateTime notifiedAt, Long voucherId,
+			LocalDateTime checkedAt) {
 		this.id = id;
 		this.type = type;
 		this.message = message;
 		this.notifiedAt = notifiedAt;
 		this.voucherId = voucherId;
+		this.checkedAt = checkedAt;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
@@ -47,9 +47,11 @@ public class Notification {
 
 	private LocalDateTime deletedAt;
 
+	private LocalDateTime checkedAt;
+
 	@Builder
 	public Notification(Long id, Member receiver, Voucher voucher, NotificationType type, String message,
-			LocalDateTime createdAt, LocalDateTime deletedAt) {
+			LocalDateTime createdAt, LocalDateTime deletedAt, LocalDateTime checkedAt) {
 		this.id = id;
 		this.receiver = receiver;
 		this.voucher = voucher;
@@ -57,5 +59,10 @@ public class Notification {
 		this.message = message;
 		this.createdAt = createdAt;
 		this.deletedAt = deletedAt;
+		this.checkedAt = checkedAt;
+	}
+
+	public void setCheckedAt(LocalDateTime checkedAt) {
+		this.checkedAt = checkedAt;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
@@ -73,7 +73,12 @@ public class NotificationService {
 	 * Notification 저장 메서드
 	 */
 	public Notification save(Member member, Voucher voucher, NotificationType type, String message) {
-		Notification notification = Notification.builder().receiver(member).type(type).message(message).voucher(voucher).build();
+		Notification notification = Notification.builder()
+				.receiver(member)
+				.type(type)
+				.message(message)
+				.voucher(voucher)
+				.build();
 		return notificationRepository.save(notification);
 	}
 

--- a/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
@@ -60,8 +60,7 @@ public class NotificationControllerTest {
 		when(jwtProvider.getUsername(anyString())).thenReturn(username);
 		when(notificationService.list(username)).thenReturn(notifications);
 		// then
-		mockMvc.perform(get("/notifications")
-						.header("Authorization", "Bearer " + accessToken))
+		mockMvc.perform(get("/notifications").header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.data[0].id").value(1L))
 				.andExpect(jsonPath("$.data[0].type").value("유효기간 임박 알림"))
@@ -79,9 +78,7 @@ public class NotificationControllerTest {
 		// given
 		String accessToken = "my.access.token";
 		String username = "이진우";
-		DeviceTokenSaveRequestDto deviceTokenSaveRequestDto = DeviceTokenSaveRequestDto.builder()
-				.token("my.device.token")
-				.build();
+		DeviceTokenSaveRequestDto deviceTokenSaveRequestDto = DeviceTokenSaveRequestDto.builder().token("my.device.token").build();
 
 		// when
 		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
@@ -89,10 +86,33 @@ public class NotificationControllerTest {
 		when(notificationService.saveDeviceToken(username, deviceTokenSaveRequestDto.getToken())).thenReturn(true);
 
 		// then
-		mockMvc.perform(post("/notifications/device")
-						.header("Authorization", "Bearer " + accessToken)
-						.contentType("application/json")
-						.content(objectMapper.writeValueAsString(deviceTokenSaveRequestDto)))
+		mockMvc.perform(post("/notifications/device").header("Authorization", "Bearer " + accessToken)
+				.contentType("application/json")
+				.content(objectMapper.writeValueAsString(deviceTokenSaveRequestDto))).andExpect(status().isOk()).andReturn();
+	}
+
+	/**
+	 * 알림 상세 조회 테스트
+	 */
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void readNotificationTest() throws Exception {
+		String accessToken = "myAccessToken";
+		String username = "이진우";
+		NotificationReadResponseDto notificationReadResponseDto = NotificationReadResponseDto.builder()
+				.id(1L)
+				.type("유효기간 임박 알림")
+				.message("유효기간이 3일 남았습니다.")
+				.voucherId(1L)
+				.notifiedAt(LocalDateTime.now())
+				.checkedAt(LocalDateTime.now())
+				.build();
+		// when
+		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
+		when(jwtProvider.getUsername(anyString())).thenReturn(username);
+		when(notificationService.read(1L, username)).thenReturn(notificationReadResponseDto);
+		// then
+		mockMvc.perform(get("/notifications/1").header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andReturn();
 	}

--- a/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationControllerTest.java
@@ -87,8 +87,10 @@ public class NotificationControllerTest {
 
 		// then
 		mockMvc.perform(post("/notifications/device").header("Authorization", "Bearer " + accessToken)
-				.contentType("application/json")
-				.content(objectMapper.writeValueAsString(deviceTokenSaveRequestDto))).andExpect(status().isOk()).andReturn();
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(deviceTokenSaveRequestDto)))
+				.andExpect(status().isOk())
+				.andReturn();
 	}
 
 	/**


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
[클라이언트에서 알림 확인 여부를 서버 측에서 관리하는 것을 요청하였습니다.](https://swm-repl.atlassian.net/browse/GH-251)
### Problem Solving
<!-- 해결 방법 -->
알림 상세 조회하는 API를 구현하였고, 상세 조회 시 `notification`의 `check_at`  시간을 기록하여 저장하였습니다.
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
`notification` 엔티티의 `checked_at` 을 `setter`를 이용해 값을 변경해주었습니다. 
