### PR TITLE
Fixed Push Notification

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/DeviceToken.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/DeviceToken.java
@@ -26,7 +26,7 @@ public class DeviceToken extends BaseTimeEntity {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Column(length = 100)
+	@Column(length = 200)
 	private String token;
 
 	@Builder

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
@@ -5,11 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.entity.DeviceToken;
 import org.swmaestro.repl.gifthub.auth.service.DeviceTokenService;
-import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.notifications.dto.FCMNotificationRequestDto;
-import org.swmaestro.repl.gifthub.util.StatusEnum;
 
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
@@ -25,8 +24,6 @@ public class FCMNotificationService {
 		List<DeviceToken> deviceTokenList = deviceTokenService.list(requestDto.getTargetMemberId());
 
 		for (DeviceToken deviceToken : deviceTokenList) {
-			System.out.println("deviceToken: " + deviceToken.getToken());
-
 			Notification notification = Notification.builder()
 					.setTitle(requestDto.getTitle())
 					.setBody(requestDto.getBody())
@@ -39,8 +36,8 @@ public class FCMNotificationService {
 
 			try {
 				firebaseMessaging.send(message);
-			} catch (Exception e) {
-				throw new BusinessException("FCM 알림 전송에 실패했습니다.", StatusEnum.INTERNAL_SERVER_ERROR);
+			} catch (FirebaseMessagingException e) {
+				deviceTokenService.delete(deviceToken.getToken());
 			}
 		}
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/ScheduledTasks.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/ScheduledTasks.java
@@ -3,7 +3,6 @@ package org.swmaestro.repl.gifthub.notifications.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.List;
 
 import org.springframework.scheduling.annotation.Scheduled;
@@ -26,12 +25,17 @@ public class ScheduledTasks {
 
 	@Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시 실행
 	public void sendExpirationNotification() {
-		Date now = new Date();
-		LocalDate today = LocalDate.of(now.getYear(), now.getMonth(), now.getDay());
+		LocalDate today = LocalDate.now();
+		List<Voucher> expiringVoucherList = voucherService.list().stream().filter(voucher -> {
+			long daysDifference = ChronoUnit.DAYS.between(today, voucher.getExpiresAt());
 
-		List<Voucher> voucherList = voucherService.list();
+			if (daysDifference <= 3 && daysDifference >= 0) {
+				return true;
+			}
+			return false;
+		}).toList();
 
-		for (Voucher voucher : voucherList) {
+		for (Voucher voucher : expiringVoucherList) {
 			long daysDifference = ChronoUnit.DAYS.between(today, voucher.getExpiresAt());
 
 			if (daysDifference <= 3) {


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

유효 기간 만료가 임박한 기프티콘이 존재함에도 불구하고 사용자에게 푸시 알림이 전송되지 않음

### Problem Solving

- Date 조회 로직 변경
- Voucher 조회 로직 변경

### To Reviewer

- `new Date().getYear`의 경우 `2023`이 아닌 `0123`을 가져오는 것을 확인하였고, 이에 따라 계산 로직을 수정하였음(시작연도가 1900으로 시작하는 것으로 추정)
- 기프티콘 리스트를 가져울 때 stream을 통해 유효 기간 만료 임박한 기프티콘만 가져오도록 함으로써 푸시 알림을 전송할 때 걸리는 시간을 단축하였음
  - 기존 : 모든 기프티콘의 유효기간을 일일히 조회 후 처리
  - 현재 : stream을 통해 유효 기간 만료 임박 기프티콘에 한해 처리
- Todo : 로그아웃 시 디바이스 토큰 삭제 필요