### PR TITLE
Add device-token deletion logic when sign-out

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
@@ -262,7 +262,6 @@ public class AuthController {
 	})
 	public ResponseEntity<Message> signOut(HttpServletRequest request, @RequestBody SignOutDto signOutDto) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
-		System.out.println("성공?:" + signOutDto.getDeviceToken());
 		authService.signOut(username, signOutDto);
 		return ResponseEntity.ok().body(
 				Message.builder()

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.swmaestro.repl.gifthub.auth.dto.GoogleDto;
 import org.swmaestro.repl.gifthub.auth.dto.KakaoDto;
 import org.swmaestro.repl.gifthub.auth.dto.NaverDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignInDto;
+import org.swmaestro.repl.gifthub.auth.dto.SignOutDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
@@ -259,17 +260,15 @@ public class AuthController {
 			@ApiResponse(responseCode = "200", description = "로그인 성공"),
 			@ApiResponse(responseCode = "400(401)", description = "존재하지 않는 사용자")
 	})
-	public ResponseEntity<Message> signOut(HttpServletRequest request) {
+	public ResponseEntity<Message> signOut(HttpServletRequest request, @RequestBody SignOutDto signOutDto) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
-		authService.signOut(username);
-		return new ResponseEntity<Message>(
+		System.out.println("성공?:" + signOutDto.getDeviceToken());
+		authService.signOut(username, signOutDto);
+		return ResponseEntity.ok().body(
 				Message.builder()
 						.status(StatusEnum.OK)
 						.message("로그아웃 성공!")
 						.data(null)
-						.build(),
-				new HttpJsonHeaders(),
-				HttpStatus.OK
-		);
+						.build());
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/SignOutDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/SignOutDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -14,4 +15,9 @@ import lombok.ToString;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class SignOutDto {
 	private String deviceToken;
+
+	@Builder
+	public SignOutDto(String deviceToken) {
+		this.deviceToken = deviceToken;
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/SignOutDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/SignOutDto.java
@@ -1,0 +1,17 @@
+package org.swmaestro.repl.gifthub.auth.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class SignOutDto {
+	private String deviceToken;
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
@@ -1,11 +1,12 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
 import org.swmaestro.repl.gifthub.auth.dto.SignInDto;
+import org.swmaestro.repl.gifthub.auth.dto.SignOutDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 
 public interface AuthService {
 
 	TokenDto signIn(SignInDto loginDto);
 
-	void signOut(String username);
+	void signOut(String username, SignOutDto signOutDto);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package org.swmaestro.repl.gifthub.auth.service;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.SignInDto;
+import org.swmaestro.repl.gifthub.auth.dto.SignOutDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.repository.MemberRepository;
@@ -21,6 +22,7 @@ public class AuthServiceImpl implements AuthService {
 	private final JwtProvider jwtProvider;
 	private final RefreshTokenService refreshTokenService;
 	private final NaverService naverService;
+	private final DeviceTokenService deviceTokenService;
 
 	public TokenDto signIn(SignInDto loginDto) {
 		Member member = memberRepository.findByUsername(loginDto.getUsername());
@@ -44,11 +46,12 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Transactional
-	public void signOut(String username) {
+	public void signOut(String username, SignOutDto signOutDto) {
 		Member member = memberRepository.findByUsername(username);
 		if (member == null) {
 			throw new BusinessException("존재하지 않는 사용자입니다.", StatusEnum.UNAUTHORIZED);
 		}
 		refreshTokenService.deleteRefreshToken(username);
+		deviceTokenService.delete(signOutDto.getDeviceToken());
 	}
 }

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import org.swmaestro.repl.gifthub.auth.dto.GoogleDto;
 import org.swmaestro.repl.gifthub.auth.dto.KakaoDto;
 import org.swmaestro.repl.gifthub.auth.dto.NaverDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignInDto;
+import org.swmaestro.repl.gifthub.auth.dto.SignOutDto;
 import org.swmaestro.repl.gifthub.auth.dto.SignUpDto;
 import org.swmaestro.repl.gifthub.auth.dto.TokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
@@ -274,11 +275,17 @@ public class AuthControllerTest {
 		String username = "jinlee1703";
 		String accessToken = "my_awesome_access_token";
 
+		SignOutDto signOutDto = SignOutDto.builder()
+				.deviceToken("my_awesome_device_token")
+				.build();
+
 		when(jwtProvider.getUsername(accessToken)).thenReturn(username);
 		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
 
 		mockMvc.perform(post("/auth/sign-out")
-						.header("Authorization", "Bearer " + accessToken))
+						.header("Authorization", "Bearer " + accessToken)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(signOutDto)))
 				.andExpect(status().isOk());
 
 	}


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

사용자가 디바이스에서 로그아웃하더라도 푸시 알림이 전송되는 현상이 발생하였음

### Problem Solving

사용자가 로그아웃 시 device token을 전송하면 서버에서 해당 로직을 수행하여 DB에 device token 삭제 처리

### To Reviewer

- 컨트롤러의 ResponseEntity 반환 방법을 한 번 수정해봤습니다! 어떤가요? ㅎㅎ