### PR TITLE
Fixed issue where created_at was not being saved

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
@@ -78,6 +78,7 @@ public class NotificationService {
 				.type(type)
 				.message(message)
 				.voucher(voucher)
+				.createdAt(LocalDateTime.now())
 				.build();
 		return notificationRepository.save(notification);
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/ScheduledTasks.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/ScheduledTasks.java
@@ -23,7 +23,7 @@ public class ScheduledTasks {
 	private final DeviceTokenService deviceTokenService;
 	private final FCMNotificationService fcmNotificationService;
 
-	@Scheduled(cron = "0 35 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시 실행
+	@Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 10시 실행
 	public void sendExpirationNotification() {
 		LocalDate today = LocalDate.now();
 		List<Voucher> expiringVoucherList = voucherService.list().stream().filter(voucher -> {
@@ -51,7 +51,7 @@ public class ScheduledTasks {
 		}
 	}
 
-	@Scheduled(cron = "0 0 10 * * ?", zone = "Asia/Seoul") // 매일 오전 9시 실행
+	@Scheduled(cron = "0 0 9 * * ?", zone = "Asia/Seoul") // 매일 오전 9시 실행
 	public void deleteDeviceToken() {
 		LocalDateTime now = LocalDateTime.now();
 


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

사용자가 알림을 조회하였을 때 알림 전송일자가 보이지 않는 문제 발생

### Problem Solving

강제로 알림 전송 시 `created_at` 컬럼에 현재 날짜 및 시간을 저장하도록 함

### To Reviewer

- 없음