### PR TITLE
Generate S3 Presigned-url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     // aws - s3
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-aws', version: '2.2.6.RELEASE'
     testImplementation group: 'io.findify', name: 's3mock_2.12', version: '0.2.6'
+    testImplementation group: 'software.amazon.awssdk', name: 's3', version: '2.20.151'
 
     // sentry
     implementation 'io.sentry:sentry-spring-boot-starter-jakarta:6.27.0'

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -13,13 +13,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 import org.swmaestro.repl.gifthub.util.HttpJsonHeaders;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
 import org.swmaestro.repl.gifthub.util.Message;
 import org.swmaestro.repl.gifthub.util.StatusEnum;
+import org.swmaestro.repl.gifthub.vouchers.dto.PresignedUrlResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
@@ -44,31 +43,22 @@ public class VoucherController {
 	private final StorageService storageService;
 	private final JwtProvider jwtProvider;
 
-	@PostMapping("/images")
-	@Operation(summary = "Voucher 이미지 등록 메서드", description = "클라이언트에서 요청한 기프티콘 이미지를 Amazon S3에 저장하기 위한 메서드입니다.")
-	@ApiResponses({
-			@ApiResponse(responseCode = "200", description = "기프티콘 이미지 등록 성공"),
-			@ApiResponse(responseCode = "400(404)", description = "존재하지 않는 브랜드 조회 시도")
-	})
-	public ResponseEntity<Message> saveVoucherImage(@RequestPart("image_file") MultipartFile imageFile) throws IOException {
-		return new ResponseEntity<>(
-				Message.builder()
-						.status(StatusEnum.OK)
-						.message("기프티콘 이미지가 성공적으로 등록되었습니다!")
-						.data(storageService.save(voucherDirName, imageFile))
-						.build(),
-				new HttpJsonHeaders(),
-				HttpStatus.OK
-		);
-	}
-
 	@GetMapping("/images")
 	@Operation(summary = "Voucher 이미지 등록 메서드", description = "클라이언트에서 요청한 기프티콘 이미지를 Amazon S3에 저장하기 위한 메서드입니다. 요청 시 S3 PreSigned URL이 반환됩니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "성공적으로 S3 Presigned URL 반환"),
 	})
-	public ResponseEntity<String> saveVoucherImage() throws IOException {
-		return ResponseEntity.ok(storageService.getPresignedUrlForSaveVoucher("AAA"));
+	public ResponseEntity<Message> saveVoucherImage() throws IOException {
+		PresignedUrlResponseDto presignedUrlResponseDto = PresignedUrlResponseDto.builder()
+				.presignedUrl(storageService.getPresignedUrlForSaveVoucher("voucher", "PNG"))
+				.build();
+
+		return ResponseEntity.ok(Message.builder()
+				.status(StatusEnum.OK)
+				.message("성공적으로 S3 Presigned URL 반환되었습니다!")
+				.data(presignedUrlResponseDto)
+				.build()
+		);
 	}
 
 	@PostMapping

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -62,6 +62,15 @@ public class VoucherController {
 		);
 	}
 
+	@GetMapping("/images")
+	@Operation(summary = "Voucher 이미지 등록 메서드", description = "클라이언트에서 요청한 기프티콘 이미지를 Amazon S3에 저장하기 위한 메서드입니다. 요청 시 S3 PreSigned URL이 반환됩니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "성공적으로 S3 Presigned URL 반환"),
+	})
+	public ResponseEntity<String> saveVoucherImage() throws IOException {
+		return ResponseEntity.ok(storageService.getPresignedUrlForSaveVoucher("AAA"));
+	}
+
 	@PostMapping
 	@Operation(summary = "Voucher 등록 메서드", description = "클라이언트에서 요청한 기프티콘 정보를 저장하기 위한 메서드입니다.")
 	@ApiResponses({

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/PresignedUrlResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/PresignedUrlResponseDto.java
@@ -1,0 +1,21 @@
+package org.swmaestro.repl.gifthub.vouchers.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class PresignedUrlResponseDto {
+	private String presignedUrl;
+
+	@Builder
+	public PresignedUrlResponseDto(String presignedUrl) {
+		this.presignedUrl = presignedUrl;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
@@ -61,13 +61,11 @@ public class StorageService {
 		return "http://" + bucketName + "/" + dirName + "/" + defaultImageFile;
 	}
 
-	public String getPresignedUrlForSaveVoucher(String fileName) {
-		String uuidFileName = getUUidFileName(fileName);
-		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, uuidFileName)
-				.withMethod(HttpMethod.PUT)
-				.withExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 5));
-		// .withContentType("image/jpeg")
-		// .withContentType("image/png");
+	public String getPresignedUrlForSaveVoucher(String dirName, String extension) {
+		String key = dirName + "/" + UUID.randomUUID().toString() + "." + extension;
+		GeneratePresignedUrlRequest generatePresignedUrlRequest =
+				new GeneratePresignedUrlRequest(bucketName, key, HttpMethod.PUT)
+						.withExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 5));
 		return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString();
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
@@ -2,6 +2,7 @@ package org.swmaestro.repl.gifthub.vouchers.service;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Date;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.swmaestro.repl.gifthub.vouchers.dto.S3FileDto;
 
+import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 
@@ -56,5 +59,15 @@ public class StorageService {
 
 	public String getDefaultImagePath(String dirName) {
 		return "http://" + bucketName + "/" + dirName + "/" + defaultImageFile;
+	}
+
+	public String getPresignedUrlForSaveVoucher(String fileName) {
+		String uuidFileName = getUUidFileName(fileName);
+		GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, uuidFileName)
+				.withMethod(HttpMethod.PUT)
+				.withExpiration(new Date(System.currentTimeMillis() + 1000 * 60 * 5));
+		// .withContentType("image/jpeg")
+		// .withContentType("image/png");
+		return amazonS3Client.generatePresignedUrl(generatePresignedUrlRequest).toString();
 	}
 }


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

이미지 등록 시 서버 부하를 줄이기 위해

### Problem Solving

AWS S3 Presigned URL을 발급받아 Client가 이미지를 직접 저장할 수 있는 URL을 제공하도록 구현하였음

### To Reviewer

- **Presigned-url을 통한 이미지 등록 시 HTTP 메서드는 `PUT`임**

- Request
	
	<img width="921" alt="image" src="https://github.com/SWM-REPL/gifthub-was/assets/68031450/2eb5056f-98a9-40d3-a9d7-ddd98278ef5c">

- Response

	<img width="842" alt="image" src="https://github.com/SWM-REPL/gifthub-was/assets/68031450/3cc6ca68-7c9b-47ee-b633-5fe89b6f1a64">

- 우려점
	- 현재 파일의 확장자(혹은) 타입이나 크기에 대해 소스코드에서 제어를 하고 있지는 않음
		- bucket에서 제어를 해야함 => 완료
- 관련 정리 : https://jinlee.kr/web/2023-09-18-s3-presiend-url/