### PR TITLE
Modify security exception-handling

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
@@ -15,9 +15,12 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.swmaestro.repl.gifthub.filter.JwtAuthenticationFilter;
+import org.swmaestro.repl.gifthub.util.Message;
+import org.swmaestro.repl.gifthub.util.StatusEnum;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.sentry.Sentry;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -48,27 +52,31 @@ public class SecurityConfig {
 						.accessDeniedHandler(new AccessDeniedHandler() {
 							@Override
 							public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
-									IOException,
-									ServletException,
 									IOException {
 								// 권한 문제가 발생했을 때 이 부분을 호출한다.
 								response.setStatus(403);
 								response.setCharacterEncoding("utf-8");
-								response.setContentType("text/html; charset=UTF-8");
-								response.getWriter().write("권한이 없습니다.");
-								Sentry.captureException(accessDeniedException);
+								response.setContentType("application/json");
+								response.getWriter().write(objectMapper.writeValueAsString(
+										Message.builder()
+												.status(StatusEnum.FORBIDDEN)
+												.message("권한이 없습니다.")
+												.build()));
 							}
 						})
 						.authenticationEntryPoint(new AuthenticationEntryPoint() {
 							@Override
 							public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
-									IOException,
-									ServletException {
+									IOException {
 								// 인증문제가 발생했을 때 이 부분을 호출한다.
 								response.setStatus(401);
 								response.setCharacterEncoding("utf-8");
-								response.setContentType("text/html; charset=UTF-8");
-								response.getWriter().write("인증되지 않은 사용자입니다.");
+								response.setContentType("application/json");
+								response.getWriter().write(objectMapper.writeValueAsString(
+										Message.builder()
+												.status(StatusEnum.FORBIDDEN)
+												.message("인증되지 않은 사용자입니다.")
+												.build()));
 								Sentry.captureException(authException);
 							}
 						})

--- a/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
 							public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws
 									IOException {
 								// 권한 문제가 발생했을 때 이 부분을 호출한다.
-								response.setStatus(403);
+								response.setStatus(400);
 								response.setCharacterEncoding("utf-8");
 								response.setContentType("application/json");
 								response.getWriter().write(objectMapper.writeValueAsString(
@@ -69,12 +69,12 @@ public class SecurityConfig {
 							public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
 									IOException {
 								// 인증문제가 발생했을 때 이 부분을 호출한다.
-								response.setStatus(401);
+								response.setStatus(400);
 								response.setCharacterEncoding("utf-8");
 								response.setContentType("application/json");
 								response.getWriter().write(objectMapper.writeValueAsString(
 										Message.builder()
-												.status(StatusEnum.FORBIDDEN)
+												.status(StatusEnum.UNAUTHORIZED)
 												.message("인증되지 않은 사용자입니다.")
 												.build()));
 								Sentry.captureException(authException);

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/AuthControllerTest.java
@@ -133,7 +133,7 @@ public class AuthControllerTest {
 
 		mockMvc.perform(post("/auth/refresh")
 						.header("Authorization", refreshToken))
-				.andExpect(status().isUnauthorized());
+				.andExpect(status().is4xxClientError());
 	}
 
 	@Test


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

- FE의 401 및 403 에러 발생 시 예외 처리 형식 단일화 요청

### Problem Solving

- SecurityConfig 수정

### To Reviewer

- 현재 에러 코드는 400, response body의 `status_code`를 401 혹은 403으로 처리 중

	<img width="1282" alt="image" src="https://github.com/SWM-REPL/gifthub-was/assets/68031450/863815e8-a836-48f5-855a-7cb89fea2e02">

- 추후 API 응답 형식 수정 시 재수정 예정