### PR TITLE
Fixed an issue where `create_date` was not saved when registering a notification

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum NotificationType {
 	EXPIRATION(0, "유효기간 임박 알림"),     // 유효기간 임박
-	RECOMMENDATION(1, "사용 추천 알림");   // 사용 추천
+	// RECOMMENDATION(1, "사용 추천 알림"),   // 사용 추천
+	NOTICE(1, "공지사항 알림");           // 공지사항
 
 	private final int value;
 	private final String description;

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
@@ -102,13 +102,10 @@ public class NotificationController {
 	})
 	public ResponseEntity<Message> sendNotification(@RequestBody NoticeNotificationDto noticeNotificationDto) {
 		fcmNotificationService.sendNotification(noticeNotificationDto);
-		return new ResponseEntity<>(
+		return ResponseEntity.ok(
 				Message.builder()
 						.status(StatusEnum.OK)
 						.message("알림 전송에 성공하였습니다!")
-						.build(),
-				new HttpJsonHeaders(),
-				HttpStatus.OK
-		);
+						.build());
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
@@ -2,13 +2,15 @@ package org.swmaestro.repl.gifthub.notifications.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.notifications.NotificationType;
-import org.swmaestro.repl.gifthub.util.BaseTimeEntity;
 import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,7 +24,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification extends BaseTimeEntity {
+@EntityListeners(AuditingEntityListener.class)
+public class Notification {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -40,6 +43,10 @@ public class Notification extends BaseTimeEntity {
 
 	@Column(columnDefinition = "TINYTEXT", length = 200, nullable = false)
 	private String message;
+
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
 
 	private LocalDateTime deletedAt;
 

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
@@ -2,9 +2,9 @@ package org.swmaestro.repl.gifthub.notifications.entity;
 
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.CreatedDate;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.notifications.NotificationType;
+import org.swmaestro.repl.gifthub.util.BaseTimeEntity;
 import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
 
 import jakarta.persistence.Column;
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -31,8 +31,8 @@ public class Notification {
 	@JoinColumn(name = "receiver_id", nullable = false)
 	private Member receiver;
 
-	@ManyToOne
-	@JoinColumn(name = "voucher_id", nullable = false)
+	@ManyToOne(optional = true)
+	@JoinColumn(name = "voucher_id", nullable = true)
 	private Voucher voucher;
 
 	@Column(columnDefinition = "TINYINT", length = 1, nullable = false)
@@ -41,22 +41,17 @@ public class Notification {
 	@Column(columnDefinition = "TINYTEXT", length = 200, nullable = false)
 	private String message;
 
-	@CreatedDate
-	private LocalDateTime createdAt;
-
 	private LocalDateTime deletedAt;
 
 	private LocalDateTime checkedAt;
 
 	@Builder
-	public Notification(Long id, Member receiver, Voucher voucher, NotificationType type, String message,
-			LocalDateTime createdAt, LocalDateTime deletedAt, LocalDateTime checkedAt) {
+	public Notification(Long id, Member receiver, Voucher voucher, NotificationType type, String message, LocalDateTime deletedAt, LocalDateTime checkedAt) {
 		this.id = id;
 		this.receiver = receiver;
 		this.voucher = voucher;
 		this.type = type;
 		this.message = message;
-		this.createdAt = createdAt;
 		this.deletedAt = deletedAt;
 		this.checkedAt = checkedAt;
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
@@ -61,9 +61,13 @@ public class FCMNotificationService {
 					.setBody(noticeNotificationDto.getBody())
 					.build();
 
+			org.swmaestro.repl.gifthub.notifications.entity.Notification savedNotification
+					= notificationService.save(deviceToken.getMember(), null, NotificationType.NOTICE, noticeNotificationDto.getBody());
+
 			Message message = Message.builder()
 					.setToken(deviceToken.getToken())
 					.setNotification(notification)
+					.putData("notification_id", savedNotification.getId().toString())
 					.build();
 
 			try {

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/NotificationService.java
@@ -78,7 +78,7 @@ public class NotificationService {
 				.type(type)
 				.message(message)
 				.voucher(voucher)
-				.createdAt(LocalDateTime.now())
+				// .createdAt(LocalDateTime.now())
 				.build();
 		return notificationRepository.save(notification);
 	}


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

- FE에서 Notification 등록 시 `created_at`이 저장되지 않고 있다는 이슈 건의

### Problem Solving

- 이전에 `created_at`을 직접 삽입함으로써 해결하였던 이슈였음 => 이전에 보냈던 알림은 `created_at`이 수정되지 않기 때문에 건의된 이슈로 판단됨
- `AuditingEntityListener`를 통해 구현되도록 리팩토링하였음

### To Reviewer

- 이전에 해결하였던 이슈였으나 올바르게 해결이 안된 줄 알고 있었습니다.
- 하지만 보냈던 알림은 created_at이 수정되지 않기 때문에 FE에서 건의한 것으로 판단됩니다.