### PR TITLE
Modify error-code from 500 to 400(401)

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/SecurityConfig.java
@@ -44,8 +44,7 @@ public class SecurityConfig {
 										"/swagger-ui/**",
 										"/v3/api-docs/**",
 										"/webjars/**",
-										"/error",
-										"/notifications").permitAll()
+										"/error").permitAll()
 								.anyRequest().authenticated())
 				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 				.exceptionHandling(exceptionHandling -> exceptionHandling

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/controller/NotificationController.java
@@ -22,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,10 +38,11 @@ public class NotificationController {
 	@Operation(summary = "Notification 목록 조회 메서드", description = "클라이언트에서 요청한 알림 목록 정보를 조회하기 위한 메서드입니다. 응답으로 알림 type, message, notified date, 기프티콘 정보, 알림 확인 시간을 반환합니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
+			@ApiResponse(responseCode = "400(401)", description = "유효하지 않은 토큰"),
 			@ApiResponse(responseCode = "400(404)", description = "존재하지 않는 회원"),
 	})
-	public ResponseEntity<Message> listNotification(@RequestHeader("Authorization") String accessToken) {
-		String username = jwtProvider.getUsername(accessToken.substring(7));
+	public ResponseEntity<Message> listNotification(HttpServletRequest request) {
+		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
 		return new ResponseEntity<>(
 				Message.builder()
 						.status(StatusEnum.OK)


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

만료된 토큰으로 알림 목록 조회 시 500 에러 발생

### Problem Solving

- 기존 공지 알림 전송 시 `POST` 방식으로 `/notification`에 전송하였기 때문에 SecurityConfig에 해당 uri를 열어두었음 => 삭제 처리

### To Reviewer

- 추후 공지 알림 전송을 관리자만 허용하도록 수정이 필요할 것으로 판단됩니다.
