### PR TITLE
Implement Voucher-Save-Method with No DB Information

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/util/QueryTemplateReader.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/util/QueryTemplateReader.java
@@ -1,0 +1,28 @@
+package org.swmaestro.repl.gifthub.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QueryTemplateReader {
+	private static String queryTemplatePath;
+
+	@Autowired
+	public QueryTemplateReader(@Value("${query-template-path}") String queryTemplatePath) {
+		this.queryTemplatePath = queryTemplatePath;
+	}
+
+	public static String readQueryTemplate() {
+		try {
+			return new String(Files.readAllBytes(Paths.get(queryTemplatePath)), StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			throw new RuntimeException("쿼리 템플릿을 읽지 못했습니다.", e);
+		}
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
@@ -36,14 +36,14 @@ public class Product {
 	@ColumnDefault("0")
 	private int isReusable;
 
-	@Column(nullable = false)
-	private int price;
+	@Column
+	private Integer price;
 
 	@Column(length = 200)
 	private String imageUrl;
 
 	@Builder
-	public Product(Long id, Brand brand, String name, String description, int isReusable, int price, String imageUrl) {
+	public Product(Long id, Brand brand, String name, String description, int isReusable, Integer price, String imageUrl) {
 		this.id = id;
 		this.brand = brand;
 		this.name = name;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Voucher.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Voucher.java
@@ -39,7 +39,7 @@ public class Voucher extends BaseTimeEntity {
 	@Column(length = 12, nullable = false)
 	private String barcode;
 
-	@Column(nullable = false)
+	@Column
 	private Integer balance;
 
 	@Column(nullable = false)

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/BrandService.java
@@ -34,4 +34,11 @@ public class BrandService {
 
 		return brandRepository.save(brand);
 	}
+
+	/**
+	 * 브랜드 저장 메서드 (Brand 객체 저장)
+	 */
+	public Brand save(Brand brand) {
+		return brandRepository.save(brand);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/ProductService.java
@@ -55,4 +55,11 @@ public class ProductService {
 				.build();
 		return productReadResponseDto;
 	}
+
+	/**
+	 * 상품 저장 메서드 (Product 객체 저장)
+	 */
+	public Product save(Product product) {
+		return productRepository.save(product);
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
@@ -9,11 +9,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.swmaestro.repl.gifthub.vouchers.dto.SearchResponseDto;
 
+import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
 
 @Service
+@RequiredArgsConstructor
 public class SearchService {
-	private final WebClient openSearchClient;
 
 	@Value("${opensearch.username}")
 	private String username;
@@ -22,12 +23,16 @@ public class SearchService {
 	private String password;
 	private String auth;
 
-	public SearchService(WebClient.Builder webClientBuilder, @Value("${opensearch.base-url}") String baseUrl) {
-		this.openSearchClient = webClientBuilder.baseUrl(baseUrl).build();
-	}
+	@Value("${opensearch.base-url}")
+	private String baseUrl;
+
+	private WebClient openSearchClient;
 
 	@PostConstruct
 	public void init() {
+		openSearchClient = WebClient.builder()
+				.baseUrl(baseUrl)
+				.build();
 		auth = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
 	}
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
@@ -14,14 +14,16 @@ import reactor.core.publisher.Mono;
 @Service
 public class SearchService {
 	private final WebClient openSearchClient;
+
 	@Value("${opensearch.username}")
 	private String username;
+
 	@Value("${opensearch.password}")
 	private String password;
 	private String auth;
 
-	public SearchService(WebClient.Builder webClientBuilder) {
-		this.openSearchClient = webClientBuilder.baseUrl("https://es.dev.gifthub.kr").build();
+	public SearchService(WebClient.Builder webClientBuilder, @Value("${opensearch.base-url}") String baseUrl) {
+		this.openSearchClient = webClientBuilder.baseUrl(baseUrl).build();
 	}
 
 	@PostConstruct

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
@@ -28,6 +28,8 @@ public class StorageService {
 	private final AmazonS3Client amazonS3Client;
 	@Value("${cloud.aws.s3.default-image-file}")
 	private String defaultImageFile;
+	@Value("${cloud.aws.cloudfront.bucket}")
+	private String cloudFrontBucketName;
 
 	public S3FileDto save(String dirName, MultipartFile multipartFile) throws IOException {
 		String originalFileName = multipartFile.getOriginalFilename();
@@ -58,7 +60,7 @@ public class StorageService {
 	}
 
 	public String getDefaultImagePath(String dirName) {
-		return "http://" + bucketName + "/" + dirName + "/" + defaultImageFile;
+		return "https://" + cloudFrontBucketName + "/" + dirName + "/" + defaultImageFile;
 	}
 
 	public String getPresignedUrlForSaveVoucher(String dirName, String extension) {

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -39,7 +39,6 @@ public class VoucherService {
 	private final VoucherRepository voucherRepository;
 	private final MemberService memberService;
 	private final VoucherUsageHistoryRepository voucherUsageHistoryRepository;
-	private final int defaultPrice = 500000;
 
 	/*
 		기프티콘 저장 메서드
@@ -55,7 +54,6 @@ public class VoucherService {
 					.brand(brand)
 					.name(voucherSaveRequestDto.getProductName())
 					.imageUrl(storageService.getDefaultImagePath(voucherDirName))
-					.price(defaultPrice)
 					.build();
 			return productService.save(newProduct);
 		});
@@ -156,8 +154,12 @@ public class VoucherService {
 		Voucher voucher = voucherRepository.findById(voucherId)
 				.orElseThrow(() -> new BusinessException("존재하지 않는 상품권 입니다.", StatusEnum.NOT_FOUND));
 
-		if ((voucherUpdateRequestDto.getBalance() != null) && (voucherUpdateRequestDto.getBalance() > productService.read(voucher.getProduct().getName())
-				.getPrice())) {
+		Product product = productService.read(voucher.getProduct().getName());
+
+		Integer productPrice = product.getPrice();
+		Integer voucherUpdateRequestBalance = voucherUpdateRequestDto.getBalance();
+
+		if (productPrice != null && voucherUpdateRequestBalance != null && voucherUpdateRequestBalance > productPrice) {
 			throw new BusinessException("잔액은 상품 가격보다 클 수 없습니다.", StatusEnum.BAD_REQUEST);
 		}
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -39,6 +39,7 @@ public class VoucherService {
 	private final VoucherRepository voucherRepository;
 	private final MemberService memberService;
 	private final VoucherUsageHistoryRepository voucherUsageHistoryRepository;
+	private final int defaultPrice = 500000;
 
 	/*
 		기프티콘 저장 메서드
@@ -54,7 +55,7 @@ public class VoucherService {
 					.brand(brand)
 					.name(voucherSaveRequestDto.getProductName())
 					.imageUrl(storageService.getDefaultImagePath(voucherDirName))
-					.price(0)
+					.price(defaultPrice)
 					.build();
 			return productService.save(newProduct);
 		});

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -45,10 +45,19 @@ public class VoucherService {
 	 */
 	public VoucherSaveResponseDto save(String username, VoucherSaveRequestDto voucherSaveRequestDto) throws
 			IOException {
-		Brand brand = brandService.read(voucherSaveRequestDto.getBrandName()).orElseThrow(() ->
-				new BusinessException("존재하지 않는 브랜드입니다.", StatusEnum.NOT_FOUND));
-		Product product = productService.read(brand.getId(), voucherSaveRequestDto.getProductName()).orElseThrow(() ->
-				new BusinessException("존재하지 않는 상품입니다.", StatusEnum.NOT_FOUND));
+		Brand brand = brandService.read(voucherSaveRequestDto.getBrandName()).orElseGet(() -> {
+			Optional<Brand> defaultBrand = brandService.read("기타");
+			return defaultBrand.get();
+		});
+		Product product = productService.read(brand.getId(), voucherSaveRequestDto.getProductName()).orElseGet(() -> {
+			Product newProduct = Product.builder()
+					.brand(brand)
+					.name(voucherSaveRequestDto.getProductName())
+					.imageUrl(storageService.getDefaultImagePath(voucherDirName))
+					.price(0)
+					.build();
+			return productService.save(newProduct);
+		});
 		String imageUrl = voucherSaveRequestDto.getImageUrl();
 
 		if (isDuplicateVoucher(username, voucherSaveRequestDto.getBarcode()) == true) {

--- a/src/main/resources/gpt/question.txt
+++ b/src/main/resources/gpt/question.txt
@@ -1,0 +1,10 @@
+Please categorize them into 4 categories: brand name, product name, expiration date, and barcode number.
+But please keep this format and return it based on Korean.
+And Return the expiration date in this format, where year is a 4-digit number and month and day are 2-digit numbers.
+And the barcode number has 12 digits. Remove any hyphens or spaces and return it as 12 consecutive digits.
+If you can't categorize it, return an empty value in the JSON structure below.
+"year-month-day"
+{"brand_name" :
+"product_name" :
+"expires_at" :
+"barcode":  }

--- a/src/main/resources/gpt/voucher-query-template.json
+++ b/src/main/resources/gpt/voucher-query-template.json
@@ -1,0 +1,18 @@
+{
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "match": {
+            "brand_name": "%s"
+          }
+        },
+        {
+          "match": {
+            "product_name": "%s"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
DB에 브랜드, 상품 정보가 없는 기프티콘도 저장할 수 있도록 변경하고자 했습니다.

### Problem Solving
<!-- 해결 방법 -->
검색결과가 없을 경우에

- `brand` -> 기타'
- `product name` -> 사용자가 저장하려는 기프티콘 상품명
- `brand` 이미지, `product` 이미지 -> `logo.png`
- `price` -> null
- `is_reusable` -> 0 (금액권 X)

으로 저장되게 했습니다.

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
기타 product, 즉 product price가 null 인 경우의 voucher는 자유롭게 balance 수정이 가능하게하고
product price가 null 이 아닌 경우에는 voucher balance의 값은 product price를 넘지 못하도록 하였습니다.
