### PR TITLE
Preprocess to korean unit in product-name to search performance improvements 

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/util/ProductNameProcessor.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/util/ProductNameProcessor.java
@@ -1,0 +1,48 @@
+package org.swmaestro.repl.gifthub.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveRequestDto;
+
+@Service
+public class ProductNameProcessor {
+
+	private static final Pattern AMOUNT_PATTERN = Pattern.compile("[\\d,]+(?=원)");
+
+	public VoucherSaveRequestDto preprocessing(VoucherSaveRequestDto voucherSaveRequestDto) {
+		String productName = voucherSaveRequestDto.getProductName();
+		Matcher matcher = AMOUNT_PATTERN.matcher(productName);
+
+		StringBuffer sb = new StringBuffer();
+
+		while (matcher.find()) {
+			String match = matcher.group();
+			int number = Integer.parseInt(match.replace(",", ""));
+			String koreanNumber = convertNumberToKorean(number);
+			matcher.appendReplacement(sb, koreanNumber);
+		}
+		matcher.appendTail(sb);
+
+		voucherSaveRequestDto.setProductName(sb.toString());
+		return voucherSaveRequestDto;
+	}
+
+	private String convertNumberToKorean(int number) {
+		String[] units = {"", "십", "백", "천", "만", "십만", "백만", "천만"};
+
+		StringBuilder result = new StringBuilder();
+		String numStr = String.valueOf(number);
+		int length = numStr.length();
+
+		for (int i = 0; i < length; i++) {
+			int digit = Integer.parseInt(Character.toString(numStr.charAt(i)));
+			if (digit != 0) {
+				result.append(digit).append(units[length - i - 1]);
+			}
+		}
+
+		return result.toString();
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -1,10 +1,15 @@
 package org.swmaestro.repl.gifthub.vouchers.service;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.notifications.service.FCMNotificationService;
+import org.swmaestro.repl.gifthub.util.ProductNameProcessor;
 import org.swmaestro.repl.gifthub.util.QueryTemplateReader;
 import org.swmaestro.repl.gifthub.util.StatusEnum;
 import org.swmaestro.repl.gifthub.vouchers.dto.GptResponseDto;
@@ -26,6 +31,7 @@ public class VoucherSaveService {
 	private final ObjectMapper objectMapper;
 	private final FCMNotificationService fcmNotificationService;
 	private final QueryTemplateReader queryTemplateReader;
+	private final ProductNameProcessor productNameProcessor;
 
 	public void execute(OCRDto ocrDto, String username) throws IOException {
 		handleGptResponse(ocrDto, username)
@@ -59,7 +65,7 @@ public class VoucherSaveService {
 	}
 
 	public Mono<VoucherSaveRequestDto> handleSearchResponse(VoucherSaveRequestDto voucherSaveRequestDto, String username) {
-		return searchService.search(createQuery(voucherSaveRequestDto)).flatMap(searchResponseDto -> {
+		return searchService.search(createQuery(productNameProcessor.preprocessing(voucherSaveRequestDto))).flatMap(searchResponseDto -> {
 			try {
 				String brandName = searchResponseDto.getHits().getHitsList().get(0).getSource().getBrandName();
 				String productName = searchResponseDto.getHits().getHitsList().get(0).getSource().getProductName();
@@ -96,9 +102,52 @@ public class VoucherSaveService {
 	}
 
 	private String createQuery(VoucherSaveRequestDto voucherSaveRequestDto) {
+		System.out.println("voucherSaveRequestDto.getproductname() = " + voucherSaveRequestDto.getProductName());
 		String queryTemplate = queryTemplateReader.readQueryTemplate();
 		return String.format(queryTemplate,
 				voucherSaveRequestDto.getBrandName(),
 				voucherSaveRequestDto.getProductName());
+	}
+
+	private VoucherSaveRequestDto preprocessing(VoucherSaveRequestDto voucherSaveRequestDto) {
+		Pattern pattern = Pattern.compile("[\\d,]+(?=원)");
+		String productName = voucherSaveRequestDto.getProductName();
+		Matcher matcher = pattern.matcher(productName);
+
+		while (matcher.find()) {
+			String match = matcher.group();
+			int number = Integer.parseInt(match.replace(",", ""));
+
+			String koreanNumber = convertNumberToKorean(number);
+
+			productName = productName.replace(match, koreanNumber);
+			voucherSaveRequestDto.setProductName(productName);
+		}
+		return voucherSaveRequestDto;
+	}
+
+	private String convertNumberToKorean(int number) {
+		Map<Integer, String> koreanUnits = new HashMap<>();
+		koreanUnits.put(100, "백");
+		koreanUnits.put(1000, "천");
+		koreanUnits.put(10000, "만");
+
+		String result = "";
+		int start = 1000;
+		int x = number / start;
+		int y = number % start;
+
+		if (x >= 10) {
+			start *= 10;
+			x = number / start;
+			y = number % start;
+		}
+
+		if (String.valueOf(y).charAt(0) == '0') {
+			result = x + koreanUnits.get(start);
+		} else {
+			result = x + koreanUnits.get(start) + String.valueOf(y).charAt(0) + koreanUnits.get(start / 10);
+		}
+		return result;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -1,10 +1,6 @@
 package org.swmaestro.repl.gifthub.vouchers.service;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
@@ -108,46 +104,5 @@ public class VoucherSaveService {
 				voucherSaveRequestDto.getBrandName(),
 				voucherSaveRequestDto.getProductName());
 	}
-
-	private VoucherSaveRequestDto preprocessing(VoucherSaveRequestDto voucherSaveRequestDto) {
-		Pattern pattern = Pattern.compile("[\\d,]+(?=원)");
-		String productName = voucherSaveRequestDto.getProductName();
-		Matcher matcher = pattern.matcher(productName);
-
-		while (matcher.find()) {
-			String match = matcher.group();
-			int number = Integer.parseInt(match.replace(",", ""));
-
-			String koreanNumber = convertNumberToKorean(number);
-
-			productName = productName.replace(match, koreanNumber);
-			voucherSaveRequestDto.setProductName(productName);
-		}
-		return voucherSaveRequestDto;
-	}
-
-	private String convertNumberToKorean(int number) {
-		Map<Integer, String> koreanUnits = new HashMap<>();
-		koreanUnits.put(100, "백");
-		koreanUnits.put(1000, "천");
-		koreanUnits.put(10000, "만");
-
-		String result = "";
-		int start = 1000;
-		int x = number / start;
-		int y = number % start;
-
-		if (x >= 10) {
-			start *= 10;
-			x = number / start;
-			y = number % start;
-		}
-
-		if (String.valueOf(y).charAt(0) == '0') {
-			result = x + koreanUnits.get(start);
-		} else {
-			result = x + koreanUnits.get(start) + String.valueOf(y).charAt(0) + koreanUnits.get(start / 10);
-		}
-		return result;
-	}
 }
+

--- a/src/main/resources/gpt/question.txt
+++ b/src/main/resources/gpt/question.txt
@@ -1,5 +1,9 @@
-Please categorize them into 4 categories: brand name, product name, expiration date, and barcode number.
+Please categorize them into 4 categories: brand name(where to use products or gift certificates), product name(gift certificates to use), expiration date, and barcode number.
 But please keep this format and return it based on Korean.
+However, you don't have to choose only one category from the given strings, you can combine the given strings to categorize them.
+For example, given the string ["Iced Café Americano T2", "+ Mascarpone Tiramisu", "Say", "THANKS"], categorize "Iced Café Americano T2 + Mascarpone Tiramisu" as product_name.
+
+The contents of the strings in the list in the given texts json should not be changed, only the strings in the list themselves should be sorted.
 And Return the expiration date in this format, where year is a 4-digit number and month and day are 2-digit numbers.
 And the barcode number has 12 digits. Remove any hyphens or spaces and return it as 12 consecutive digits.
 If you can't categorize it, return an empty value in the JSON structure below.

--- a/src/main/resources/opensearch/voucher-query-template.json
+++ b/src/main/resources/opensearch/voucher-query-template.json
@@ -1,12 +1,14 @@
 {
   "query": {
     "bool": {
-      "should": [
+      "filter": [
         {
-          "match": {
-            "brand_name": "%s"
+          "term": {
+            "brand_name.keyword": "%s"
           }
-        },
+        }
+      ],
+      "must": [
         {
           "match": {
             "product_name": "%s"


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 문서 작성

### Motivation 
<!-- 작성 배경 -->
- Opensearch의 tokenizer를 `ngram`으로 바꾸고 나서, 검색 score에 이상이 있었습니다.
	그 이유는 상품명이 `50,000원` 인 경우 `0`의 개수가 많아서 `500,000원`이 검색되는 것이었습니다.
### Problem Solving
<!-- 해결 방법 -->
-  product_name의 금액 숫자 표기를 단위 숫자 표기로 변환하는 전처리 과정을 추가했습니다.
	- 500원 -> 5백원
	- 50,000원 -> 5만원
- 검색 시, 브랜드로 먼저 필터링 한 후, 유사한 product_name을 검색하도록 쿼리를 변경하였습니다.
	- `brand_name`: 스타벅스, `product_name` :  문화 상품권 -> 검색 X 
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
`ProductNameProcessor.java`를 우선 `util` 디렉토리에 넣긴 했지만,  `voucher` 디렉토리에 위치시킬지 `util` 디렉토리에 위치시키는게 좋을지 고민입니다.