### PR TITLE
Implement Voucher Pending when voucher is registered automatically

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/NotificationType.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum NotificationType {
 	EXPIRATION(0, "유효기간 임박 알림"),     // 유효기간 임박
 	// RECOMMENDATION(1, "사용 추천 알림"),   // 사용 추천
-	NOTICE(1, "공지사항 알림");           // 공지사항
+	NOTICE(1, "공지사항 알림"), // 공지사항
+	REGISTERED(2, "등록처리 알림"); // 등록처리 알람
 
 	private final int value;
 	private final String description;

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/entity/Notification.java
@@ -11,6 +11,8 @@ import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -38,7 +40,8 @@ public class Notification {
 	@JoinColumn(name = "voucher_id", nullable = true)
 	private Voucher voucher;
 
-	@Column(columnDefinition = "TINYINT", length = 1, nullable = false)
+	@Enumerated(EnumType.ORDINAL)
+	@Column(columnDefinition = "TINYINT", nullable = false)
 	private NotificationType type;
 
 	@Column(columnDefinition = "TINYTEXT", length = 200, nullable = false)

--- a/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/notifications/service/FCMNotificationService.java
@@ -52,6 +52,11 @@ public class FCMNotificationService {
 		}
 	}
 
+	/**
+	 * 모든 회원에게 알림을 보내는 메서드
+	 * @param noticeNotificationDto
+	 */
+
 	public void sendNotification(NoticeNotificationDto noticeNotificationDto) {
 		List<DeviceToken> deviceTokenList = deviceTokenService.list();
 
@@ -79,11 +84,18 @@ public class FCMNotificationService {
 	}
 
 	/**
-	 * 특정 회원에게 알림을 보내는 메서드(username으로 검색)
+	 * title과 body를 받아서 특정 회원에게 알림을 보내는 메서드(username으로 검색)
 	 */
-	public void sendNotification(NoticeNotificationDto noticeNotificationDto, String username) {
+	public void sendNotification(String title, String body, String username) {
 		Member member = memberService.read(username);
+
+		NoticeNotificationDto noticeNotificationDto = NoticeNotificationDto.builder()
+				.title(title)
+				.body(body)
+				.build();
+
 		List<DeviceToken> deviceTokenList = deviceTokenService.list(member.getId());
+
 		for (DeviceToken deviceToken : deviceTokenList) {
 			Notification notification = Notification.builder()
 					.setTitle(noticeNotificationDto.getTitle())
@@ -93,6 +105,7 @@ public class FCMNotificationService {
 			Message message = Message.builder()
 					.setToken(deviceToken.getToken())
 					.setNotification(notification)
+					.putData("notification_type", NotificationType.REGISTERED.toString())
 					.build();
 
 			try {
@@ -101,13 +114,5 @@ public class FCMNotificationService {
 				deviceTokenService.delete(deviceToken.getToken());
 			}
 		}
-	}
-
-	/**
-	 * title과 body를 받아서 특정 회원에게 알림을 보내는 메서드(username으로 검색)
-	 */
-	public void sendNotification(String title, String body, String username) {
-		NoticeNotificationDto noticeNotificationDto = NoticeNotificationDto.builder().title(title).body(body).build();
-		sendNotification(noticeNotificationDto, username);
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -1,7 +1,6 @@
 package org.swmaestro.repl.gifthub.vouchers.controller;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +18,7 @@ import org.swmaestro.repl.gifthub.util.Message;
 import org.swmaestro.repl.gifthub.util.SuccessMessage;
 import org.swmaestro.repl.gifthub.vouchers.dto.OCRDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.PresignedUrlResponseDto;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherListResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherReadResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
@@ -109,11 +109,11 @@ public class VoucherController {
 	})
 	public ResponseEntity<Message> listVoucher(HttpServletRequest request, @RequestParam(value = "user_id", required = true) Long memberId) {
 		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
-		List<Long> voucherIdList = voucherService.list(memberId, username);
+		VoucherListResponseDto voucherListResponseDto = voucherService.list(memberId, username);
 		return ResponseEntity.ok(
 				SuccessMessage.builder()
 						.path(request.getRequestURI())
-						.data(voucherIdList)
+						.data(voucherListResponseDto)
 						.build());
 	}
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/ProductReadResponseDto.java
@@ -19,11 +19,11 @@ public class ProductReadResponseDto {
 	private String name;
 	private String description;
 	private int isReusable;
-	private int price;
+	private Integer price;
 	private String imageUrl;
 
 	@Builder
-	public ProductReadResponseDto(Long id, Long brandId, String name, String description, int isReusable, int price, String imageUrl) {
+	public ProductReadResponseDto(Long id, Long brandId, String name, String description, int isReusable, Integer price, String imageUrl) {
 		this.id = id;
 		this.brandId = brandId;
 		this.name = name;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherListResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherListResponseDto.java
@@ -1,0 +1,24 @@
+package org.swmaestro.repl.gifthub.vouchers.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class VoucherListResponseDto {
+	private List<Long> voucherIds;
+	private int pendingCount;
+
+	@Builder
+	public VoucherListResponseDto(List<Long> voucherIds, int pendingCount) {
+		this.voucherIds = voucherIds;
+		this.pendingCount = pendingCount;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/PendingVoucher.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/PendingVoucher.java
@@ -1,0 +1,44 @@
+package org.swmaestro.repl.gifthub.vouchers.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PendingVoucher {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@Builder
+	public PendingVoucher(Long id, Member member) {
+		this.id = id;
+		this.member = member;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Product.java
@@ -33,7 +33,7 @@ public class Product {
 	private String description;
 
 	@Column(columnDefinition = "TINYINT", nullable = false)
-	@ColumnDefault("0")
+	@ColumnDefault("1")
 	private int isReusable;
 
 	@Column

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/repository/PendingVoucherRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/repository/PendingVoucherRepository.java
@@ -1,0 +1,10 @@
+package org.swmaestro.repl.gifthub.vouchers.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.swmaestro.repl.gifthub.vouchers.entity.PendingVoucher;
+
+public interface PendingVoucherRepository extends JpaRepository<PendingVoucher, Long> {
+	PendingVoucher findByMemberId(Long memberId);
+
+	int countByMemberId(Long memberId);
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/PendingVoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/PendingVoucherService.java
@@ -1,0 +1,36 @@
+package org.swmaestro.repl.gifthub.vouchers.service;
+
+import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
+import org.swmaestro.repl.gifthub.util.StatusEnum;
+import org.swmaestro.repl.gifthub.vouchers.entity.PendingVoucher;
+import org.swmaestro.repl.gifthub.vouchers.repository.PendingVoucherRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PendingVoucherService {
+	private final PendingVoucherRepository pendingVoucherRepository;
+
+	public void create(Member member) {
+		PendingVoucher pendingVoucher = PendingVoucher.builder()
+				.member(member)
+				.build();
+		pendingVoucherRepository.save(pendingVoucher);
+	}
+
+	public void delete(Member member) {
+		PendingVoucher pendingVoucher = pendingVoucherRepository.findByMemberId(member.getId());
+		//예외 처리
+		if (pendingVoucher == null) {
+			throw new BusinessException("PendingVoucher가 존재하지 않습니다.", StatusEnum.NOT_FOUND);
+		}
+		pendingVoucherRepository.delete(pendingVoucher);
+	}
+
+	public int count(Long memberId) {
+		return pendingVoucherRepository.countByMemberId(memberId);
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -81,7 +81,6 @@ public class VoucherSaveService {
 				}
 				return Mono.just(voucherSaveRequestDto);
 			} catch (JsonProcessingException e) {
-				// fcmNotificationService.sendNotification("기프티콘 등록 실패", "기프티콘 등록에 실패했습니다.", username);
 				return Mono.error(new BusinessException("GPT 응답이 올바르지 않습니다.", StatusEnum.NOT_FOUND));
 			}
 		});

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -13,6 +13,7 @@ import org.swmaestro.repl.gifthub.auth.service.MemberService;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.util.DateConverter;
 import org.swmaestro.repl.gifthub.util.StatusEnum;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherListResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherReadResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
@@ -39,6 +40,7 @@ public class VoucherService {
 	private final VoucherRepository voucherRepository;
 	private final MemberService memberService;
 	private final VoucherUsageHistoryRepository voucherUsageHistoryRepository;
+	private final PendingVoucherService pendingVoucherService;
 
 	/*
 		기프티콘 저장 메서드
@@ -118,7 +120,7 @@ public class VoucherService {
 	/*
 	사용자 별 기프티콘 목록 조회 메서드(userId로 조회, username으로 권한 대조)
 	 */
-	public List<Long> list(Long userId, String username) {
+	public VoucherListResponseDto list(Long userId, String username) {
 		if (!memberService.read(userId).getUsername().equals(username)) {
 			throw new BusinessException("상품권을 조회할 권한이 없습니다.", StatusEnum.FORBIDDEN);
 		}
@@ -132,7 +134,11 @@ public class VoucherService {
 			}
 			voucherIdList.add(voucher.getId());
 		}
-		return voucherIdList;
+
+		return VoucherListResponseDto.builder()
+				.voucherIds(voucherIdList)
+				.pendingCount(pendingVoucherService.count(userId))
+				.build();
 	}
 
 	/*

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherListResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherReadResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
@@ -113,9 +114,16 @@ class VoucherControllerTest {
 		voucherIdList.add(1L);
 		voucherIdList.add(2L);
 
+		int pendingCount = 2;
+
+		VoucherListResponseDto voucherListResponseDto = VoucherListResponseDto.builder()
+				.voucherIds(voucherIdList)
+				.pendingCount(pendingCount)
+				.build();
+
 		when(jwtProvider.resolveToken(any())).thenReturn(accessToken);
 		when(jwtProvider.getUsername(anyString())).thenReturn(username);
-		when(voucherService.list(memberId, username)).thenReturn(voucherIdList);
+		when(voucherService.list(memberId, username)).thenReturn(voucherListResponseDto);
 
 		mockMvc.perform(get("/vouchers?user_id=" + memberId)
 						.header("Authorization", "Bearer " + accessToken))


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
비동기로 처리되는 기프티콘 자동 등록 기능에서 처리 중인 기프티콘의 상태를 알려주고자 하였습니다.

### Problem Solving
<!-- 해결 방법 -->
1. 기프티콘 자동 등록 요청 -> 해당 member의 pending_voucher row 추가
2. 등록 완료 -> 해당 member의 pending_voucher row 삭제
3. 기프티콘 목록 조회 api 요청 -> 해당 member의 pending_voucher count 응답

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
기프티콘 수동 등록 / 자동 등록을 API를 분리하고
기존의 POST `/vouchers`를 기프티콘 수동 등록이라는 의미로 `/vouchers/manual` 로 바꾸고
현재의 POST `/vouchers/test`를 `/vouchers`로 바꾸는 건 어떨까요? 의견 주시면 감사하겠습니다!