### PR TITLE
implement delete OAuth-info API

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -10,9 +10,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
+import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
+import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
 import org.swmaestro.repl.gifthub.util.Message;
+import org.swmaestro.repl.gifthub.util.StatusEnum;
 import org.swmaestro.repl.gifthub.util.SuccessMessage;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -74,5 +78,30 @@ public class UserController {
 						.path(request.getRequestURI())
 						.data(memberService.read(userId))
 						.build());
+	}
+
+	@DeleteMapping("/oauth/{platform}")
+	@Operation(summary = "OAuth 연동 계정 삭제 메서드", description = "사용자의 기존 계정에 연동된 OAuth 계정을 삭제하기 위한 메서드입니다.\n 파라미터로는 'naver', 'kakao', 'google', 'apple'를 받을 수 있습니다.")
+	@ApiResponses({
+			@ApiResponse(responseCode = "200", description = "OAuth 연동 계정 삭제 성공"),
+			@ApiResponse(responseCode = "400", description = "OAuth 연동 계정 삭제 실패")
+	})
+	public ResponseEntity<Message> deleteOAuthInfo(HttpServletRequest request, @PathVariable String platform) {
+		OAuthPlatform oAuthPlatform;
+
+		switch (platform) {
+			case "naver" -> oAuthPlatform = OAuthPlatform.NAVER;
+			case "kakao" -> oAuthPlatform = OAuthPlatform.KAKAO;
+			case "google" -> oAuthPlatform = OAuthPlatform.GOOGLE;
+			case "apple" -> oAuthPlatform = OAuthPlatform.APPLE;
+			default -> throw new BusinessException("올바르지 않은 플랫폼에 대한 요청입니다.", StatusEnum.BAD_REQUEST);
+		}
+
+		String username = jwtProvider.getUsername(jwtProvider.resolveToken(request).substring(7));
+		Member member = memberService.read(username);
+		memberService.deleteOAuthInfo(member, oAuthPlatform);
+		return ResponseEntity.ok(SuccessMessage.builder()
+				.path(request.getRequestURI())
+				.build());
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/controller/UserController.java
@@ -11,8 +11,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
+import org.swmaestro.repl.gifthub.auth.dto.OAuthTokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
+import org.swmaestro.repl.gifthub.auth.service.OAuthService;
 import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
@@ -81,8 +83,8 @@ public class UserController {
 						.data(memberService.read(userId))
 						.build());
 	}
-  
-  @PostMapping("/oauth/{platform}")
+
+	@PostMapping("/oauth/{platform}")
 	@Operation(summary = "OAuth 연동 계정 추가 메서드", description = "사용자의 기존 계정에 OAuth 계정을 추가 연동하기 위한 메서드입니다.\n 파라미터로는 'naver', 'kakao', 'google', 'apple'를 받을 수 있습니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "OAuth 연동 계정 추가 성공"),
@@ -107,8 +109,8 @@ public class UserController {
 				.path(request.getRequestURI())
 				.build());
 	}
-  
-  @DeleteMapping("/oauth/{platform}")
+
+	@DeleteMapping("/oauth/{platform}")
 	@Operation(summary = "OAuth 연동 계정 삭제 메서드", description = "사용자의 기존 계정에 연동된 OAuth 계정을 삭제하기 위한 메서드입니다.\n 파라미터로는 'naver', 'kakao', 'google', 'apple'를 받을 수 있습니다.")
 	@ApiResponses({
 			@ApiResponse(responseCode = "200", description = "OAuth 연동 계정 삭제 성공"),

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
@@ -1,5 +1,7 @@
 package org.swmaestro.repl.gifthub.auth.entity;
 
+import java.time.LocalDateTime;
+
 import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 
 import jakarta.persistence.Column;
@@ -39,6 +41,9 @@ public class OAuth {
 	@JoinColumn(name = "member_id", nullable = false)
 	@ManyToOne
 	private Member member;
+
+	@Column
+	private LocalDateTime deletedAt;
 
 	@Builder
 	public OAuth(OAuthPlatform platform, String platformId, String email, String nickname, Member member) {

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/repository/OAuthRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/repository/OAuthRepository.java
@@ -11,4 +11,6 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 	Optional<OAuth> findByMemberAndPlatform(Member member, OAuthPlatform platform);
 
 	Optional<OAuth> findByPlatformAndPlatformId(OAuthPlatform platform, String platformId);
+
+	Optional<OAuth> deleteByMemberAndPlatform(Member member, OAuthPlatform platform);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
@@ -122,6 +122,13 @@ public class AppleService implements OAuth2Service {
 	}
 
 	@Override
+	public OAuth delete(Member member) {
+		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.APPLE).orElseThrow(
+				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
+		);
+	}
+
+	@Override
 	public boolean isExists(Member member) {
 		return oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.APPLE).isPresent();
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
@@ -3,6 +3,7 @@ package org.swmaestro.repl.gifthub.auth.service;
 import java.io.IOException;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -117,15 +118,23 @@ public class AppleService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.APPLE, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.APPLE, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
+
+		if (oAuth.getDeletedAt() != null) {
+			throw new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND);
+		} else {
+			return oAuth;
+		}
 	}
 
 	@Override
 	public OAuth delete(Member member) {
-		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.APPLE).orElseThrow(
+		OAuth oAuth = oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.APPLE).orElseThrow(
 				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
 		);
+		oAuth.setDeletedAt(LocalDateTime.now());
+		return oAuthRepository.save(oAuth);
 	}
 
 	@Override

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/GoogleService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/GoogleService.java
@@ -104,6 +104,13 @@ public class GoogleService implements OAuth2Service {
 	}
 
 	@Override
+	public OAuth delete(Member member) {
+		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.GOOGLE).orElseThrow(
+				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
+		);
+	}
+
+	@Override
 	public boolean isExists(Member member) {
 		return oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.GOOGLE).isPresent();
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
@@ -7,6 +7,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.config.KakaoConfig;
@@ -97,15 +98,23 @@ public class KakaoService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
+
+		if (oAuth.getDeletedAt() != null) {
+			throw new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND);
+		} else {
+			return oAuth;
+		}
 	}
 
 	@Override
 	public OAuth delete(Member member) {
-		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.KAKAO).orElseThrow(
+		OAuth oAuth = oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.KAKAO).orElseThrow(
 				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
 		);
+		oAuth.setDeletedAt(LocalDateTime.now());
+		return oAuthRepository.save(oAuth);
 	}
 
 	@Override

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
@@ -102,6 +102,13 @@ public class KakaoService implements OAuth2Service {
 	}
 
 	@Override
+	public OAuth delete(Member member) {
+		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.KAKAO).orElseThrow(
+				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
+		);
+	}
+
+	@Override
 	public boolean isExists(Member member) {
 		return oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.KAKAO).isPresent();
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/MemberService.java
@@ -14,9 +14,10 @@ import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
+import org.swmaestro.repl.gifthub.auth.entity.OAuth;
 import org.swmaestro.repl.gifthub.auth.repository.MemberRepository;
+import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
-import org.swmaestro.repl.gifthub.util.JwtProvider;
 import org.swmaestro.repl.gifthub.util.StatusEnum;
 
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 	private final MemberRepository memberRepository;
 	private final PasswordEncoder passwordEncoder;
-	private final JwtProvider jwtProvider;
-	private final RefreshTokenService refreshTokenService;
+	private final OAuthService oAuthService;
 
 	public Member passwordEncryption(Member member) {
 		return Member.builder()
@@ -141,5 +141,9 @@ public class MemberService {
 
 	public String generateOAuthUsername() {
 		return UUID.randomUUID().toString();
+	}
+
+	public OAuth deleteOAuthInfo(Member member, OAuthPlatform oAuthPlatform) {
+		return oAuthService.delete(member, oAuthPlatform);
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
@@ -7,6 +7,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.config.NaverConfig;
@@ -102,15 +103,23 @@ public class NaverService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.NAVER, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.NAVER, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
+
+		if (oAuth.getDeletedAt() != null) {
+			throw new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND);
+		} else {
+			return oAuth;
+		}
 	}
 
 	@Override
 	public OAuth delete(Member member) {
-		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.NAVER).orElseThrow(
+		OAuth oAuth = oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.NAVER).orElseThrow(
 				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
 		);
+		oAuth.setDeletedAt(LocalDateTime.now());
+		return oAuthRepository.save(oAuth);
 	}
 
 	@Override

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
@@ -107,6 +107,13 @@ public class NaverService implements OAuth2Service {
 	}
 
 	@Override
+	public OAuth delete(Member member) {
+		return oAuthRepository.deleteByMemberAndPlatform(member, OAuthPlatform.NAVER).orElseThrow(
+				() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND)
+		);
+	}
+
+	@Override
 	public boolean isExists(Member member) {
 		return oAuthRepository.findByMemberAndPlatform(member, OAuthPlatform.NAVER).isPresent();
 	}

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuth2Service.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuth2Service.java
@@ -33,6 +33,13 @@ public interface OAuth2Service {
 	OAuth read(OAuthUserInfoDto oAuthUserInfoDto);
 
 	/**
+	 * 연동된 OAuth 계정 정보를 삭제한다.
+	 * @param member
+	 * @return
+	 */
+	OAuth delete(Member member);
+
+	/**
 	 * OAuth 플랫폼 존재 여부를 확인한다.
 	 * @param member
 	 * @return

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuthService.java
@@ -42,6 +42,16 @@ public class OAuthService {
 		};
 	}
 
+	public OAuth delete(Member member, OAuthPlatform platform) {
+		return switch (platform) {
+			case NAVER -> naverService.delete(member);
+			case KAKAO -> kakaoService.delete(member);
+			case GOOGLE -> googleService.delete(member);
+			case APPLE -> appleService.delete(member);
+			default -> throw new BusinessException("지원하지 않는 OAuth 플랫폼입니다.", StatusEnum.INTERNAL_SERVER_ERROR);
+		};
+	}
+
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto, OAuthPlatform platform) {
 		return switch (platform) {
 			case NAVER -> naverService.read(oAuthUserInfoDto);

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -16,6 +16,7 @@ import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
+import org.swmaestro.repl.gifthub.auth.dto.OAuthTokenDto;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 import org.swmaestro.repl.gifthub.auth.entity.OAuth;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
@@ -103,8 +104,8 @@ class UserControllerTest {
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}
-  
-  @Test
+
+	@Test
 	@WithMockUser(username = "이진우", roles = "USER")
 	void createOAuthInfo() throws Exception {
 		// given
@@ -136,8 +137,8 @@ class UserControllerTest {
 						.content(objectMapper.writeValueAsString(oAuthTokenDto)))
 				.andExpect(status().isOk());
 	}
-  
-  @Test
+
+	@Test
 	@WithMockUser(username = "이진우", roles = "USER")
 	void deleteOAuthInfo() throws Exception {
 		// given

--- a/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/auth/controller/UserControllerTest.java
@@ -16,7 +16,10 @@ import org.swmaestro.repl.gifthub.auth.dto.MemberDeleteResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberReadResponseDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.MemberUpdateResponseDto;
+import org.swmaestro.repl.gifthub.auth.entity.Member;
+import org.swmaestro.repl.gifthub.auth.entity.OAuth;
 import org.swmaestro.repl.gifthub.auth.service.MemberService;
+import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 import org.swmaestro.repl.gifthub.util.JwtProvider;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -97,6 +100,34 @@ class UserControllerTest {
 
 		//then
 		mockMvc.perform(get("/users/1")
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	@WithMockUser(username = "이진우", roles = "USER")
+	void deleteOAuthInfo() throws Exception {
+		// given
+		Member member = Member.builder()
+				.username("my_username")
+				.nickname("my_nickname")
+				.password("my_password")
+				.build();
+
+		OAuth oAuth = OAuth.builder()
+				.platform(OAuthPlatform.NAVER)
+				.platformId("my_naver_unique_id")
+				.member(member)
+				.email("my_naver_email")
+				.nickname("my_naver_nickname")
+				.build();
+
+		// when
+		when(jwtProvider.resolveToken(any())).thenReturn("my_awesome_access_token");
+		when(memberService.deleteOAuthInfo(any(Member.class), any(OAuthPlatform.class))).thenReturn(oAuth);
+
+		// then
+		mockMvc.perform(delete("/users/oauth/naver")
 						.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk());
 	}


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 

사용자가 하나의 계정에 연결된 여러 개의 OAuth 계정을 해지하도록 함

### Problem Solving

사용자 계정에 연결된 OAuth 계정 해지 API 구현

### To Reviewer

- 현재 OAuth 계정 정보 삭제 시 soft-delete가 아닌 hard-delete 중 인데 이 점이 서비스 구현에 문제가 될 지와 수정이 필요할 지 의견이 궁금합니다!
