### PR TITLE
Use Voucher that Product Price is null

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUseResponseDto.java
@@ -15,10 +15,10 @@ public class VoucherUseResponseDto {
 	private Long usageId;
 	private Long voucherId;
 	private int balance;
-	private int price;
+	private Integer price;
 
 	@Builder
-	public VoucherUseResponseDto(Long usageId, Long voucherId, int balance, int price) {
+	public VoucherUseResponseDto(Long usageId, Long voucherId, int balance, Integer price) {
 		this.usageId = usageId;
 		this.voucherId = voucherId;
 		this.balance = balance;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/VoucherUsageHistory.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/VoucherUsageHistory.java
@@ -3,10 +3,12 @@ package org.swmaestro.repl.gifthub.vouchers.entity;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.swmaestro.repl.gifthub.auth.entity.Member;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class VoucherUsageHistory {
 	@Id
@@ -33,7 +36,8 @@ public class VoucherUsageHistory {
 	@JoinColumn(name = "voucher_id", nullable = false)
 	private Voucher voucher;
 
-	private int amount;
+	@Column(nullable = true)
+	private Integer amount;
 
 	private String place;
 
@@ -42,8 +46,8 @@ public class VoucherUsageHistory {
 	private LocalDateTime createdAt;
 
 	@Builder
-	public VoucherUsageHistory(Long id, Member member, Voucher voucher, int amount, String place,
-		LocalDateTime createdAt) {
+	public VoucherUsageHistory(Long id, Member member, Voucher voucher, Integer amount, String place,
+			LocalDateTime createdAt) {
 		this.id = id;
 		this.member = member;
 		this.voucher = voucher;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherUsageHistoryService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherUsageHistoryService.java
@@ -1,0 +1,31 @@
+package org.swmaestro.repl.gifthub.vouchers.service;
+
+import org.springframework.stereotype.Service;
+import org.swmaestro.repl.gifthub.auth.service.MemberService;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
+import org.swmaestro.repl.gifthub.vouchers.entity.Voucher;
+import org.swmaestro.repl.gifthub.vouchers.entity.VoucherUsageHistory;
+import org.swmaestro.repl.gifthub.vouchers.repository.VoucherUsageHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class VoucherUsageHistoryService {
+	private final VoucherUsageHistoryRepository voucherUsageHistoryRepository;
+	private final MemberService memberService;
+
+	/**
+	 * 사용 내역 저장 메서드
+	 */
+	public Long create(Voucher voucher, VoucherUseRequestDto voucherUseRequestDto, String username) {
+		VoucherUsageHistory voucherUsageHistory = VoucherUsageHistory.builder()
+				.member(memberService.read(username))
+				.voucher(voucher)
+				.amount(voucherUseRequestDto.getAmount())
+				.place(voucherUseRequestDto.getPlace())
+				.build();
+		voucherUsageHistoryRepository.save(voucherUsageHistory);
+		return voucherUsageHistory.getId();
+	}
+}


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
Product price가 null 인 상품이 생기며 기프티콘 사용 로직에 문제가 생겼었습니다.
### Problem Solving
<!-- 해결 방법 -->
DB에 없는 정보를 가진 Product가 생성될 때 **reusable**을 1로 설정합니다.
**non-reusable voucher** 혹은 **voucher balance가 null** 인 voucher를 사용하려고 할 때 클라이언트에서 사용 요청 금액을 **null** 로 보냅니다.

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
다음과 같이 예외처리를 하였습니다.


Voucher | DB에 정보 X | DB에 정보 X | DB에 정보 O | DB에 정보 O
-- | -- | -- | -- | --
product price | null | null | not null | not null
voucher balance | null | not null | not null | not null
reusable | 1 | 1 | 0 | 1
requestDto.amount == null | 사용 완료 | 400 에러 | 사용 완료 | 400에러
requestDto.amount == not null | 400 에러 | 사용 가능 | 400에러 | 사용 가능


<!-- notionvc: 25324aff-aaec-4c08-b2cf-a273a12fbe22 -->