### PR TITLE
Modify refresh-token save and duplicated device-token logic

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
@@ -46,7 +46,9 @@ public class AuthService {
 				.build();
 
 		User savedUser = userService.create(user);
-		return generateJwtTokenDto(savedUser);
+		JwtTokenDto jwtTokenDto = generateJwtTokenDto(savedUser);
+		refreshTokenService.storeRefreshToken(jwtTokenDto, savedUser.getUsername());
+		return jwtTokenDto;
 	}
 
 	/**

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AuthService.java
@@ -71,7 +71,7 @@ public class AuthService {
 				.accessToken(accessToken)
 				.refreshToken(refreshToken)
 				.build();
-
+		refreshTokenService.storeRefreshToken(jwtTokenDto, user.getUsername());
 		return jwtTokenDto;
 	}
 
@@ -101,8 +101,9 @@ public class AuthService {
 			// oauth 정보 저장
 			oAuth = oAuthService.create(user, userInfo, platform);
 		}
-
-		return generateJwtTokenDto(oAuth.getUser());
+		JwtTokenDto jwtTokenDto = generateJwtTokenDto(oAuth.getUser());
+		refreshTokenService.storeRefreshToken(jwtTokenDto, oAuth.getUser().getUsername());
+		return jwtTokenDto;
 	}
 
 	/**
@@ -134,6 +135,5 @@ public class AuthService {
 			throw new BusinessException("존재하지 않는 사용자입니다.", StatusEnum.UNAUTHORIZED);
 		}
 		refreshTokenService.deleteRefreshToken(username);
-		deviceTokenService.delete(signOutDto.getDeviceToken());
 	}
 }


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
1. Sign-in 시 refresh token 저장이 안되고 있었음
2. Device token 삭제하는 API 를 따로 분리했는데, sign-out 안에 delete device token 로직이 중복되고 있었음
### Problem Solving
<!-- 해결 방법 -->

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
