### PR TITLE
Modify OAuth Logic when User Deleted and Re sign-in

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
@@ -29,7 +29,7 @@ public class OAuth {
 	@Column(columnDefinition = "TINYINT", nullable = false)
 	private OAuthPlatform platform;
 
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String platformId;
 
 	@Column
@@ -38,7 +38,7 @@ public class OAuth {
 	@Column
 	private String nickname;
 
-	@JoinColumn(name = "user_id")
+	@JoinColumn(name = "user_id", nullable = false)
 	@ManyToOne
 	private User user;
 

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/OAuth.java
@@ -38,7 +38,7 @@ public class OAuth {
 	@Column
 	private String nickname;
 
-	@JoinColumn(name = "user_id", nullable = false)
+	@JoinColumn(name = "user_id")
 	@ManyToOne
 	private User user;
 
@@ -52,5 +52,9 @@ public class OAuth {
 		this.email = email;
 		this.nickname = nickname;
 		this.user = user;
+	}
+
+	public boolean isDeleted() {
+		return deletedAt != null;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/User.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/User.java
@@ -90,6 +90,6 @@ public class User extends BaseTimeEntity implements UserDetails {
 
 	@Override
 	public boolean isEnabled() {
-		return true;
+		return this.deletedAt == null;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/repository/OAuthRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/repository/OAuthRepository.java
@@ -1,5 +1,6 @@
 package org.swmaestro.repl.gifthub.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,8 @@ public interface OAuthRepository extends JpaRepository<OAuth, Long> {
 	Optional<OAuth> findByPlatformAndPlatformId(OAuthPlatform platform, String platformId);
 
 	Optional<OAuth> deleteByUserAndPlatform(User user, OAuthPlatform platform);
+
+	List<OAuth> findAllByUser(User user);
+
+	Optional<OAuth> findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform platform, String platformId);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/AppleService.java
@@ -118,7 +118,7 @@ public class AppleService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.APPLE, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.APPLE, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
 
 		if (oAuth.getDeletedAt() != null) {
@@ -144,6 +144,6 @@ public class AppleService implements OAuth2Service {
 
 	@Override
 	public boolean isExists(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.APPLE, oAuthUserInfoDto.getId()).isPresent();
+		return oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.APPLE, oAuthUserInfoDto.getId()).isPresent();
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/GoogleService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/GoogleService.java
@@ -57,9 +57,9 @@ public class GoogleService implements OAuth2Service {
 
 			br.close();
 
-			JsonElement responseElement = parser.parse(result).getAsJsonObject().get("response").getAsJsonObject();
+			JsonElement responseElement = parser.parse(result).getAsJsonObject();
 
-			String id = getStringOrNull(responseElement, "id");
+			String id = getStringOrNull(responseElement, "sub");
 			String email = getStringOrNull(responseElement, "email");
 			String nickname = getStringOrNull(responseElement, "name");
 
@@ -121,12 +121,15 @@ public class GoogleService implements OAuth2Service {
 
 	@Override
 	public boolean isExists(User user) {
+		if (!user.isEnabled()) {
+			throw new BusinessException("탈퇴한 회원입니다.", StatusEnum.BAD_REQUEST);
+		}
 		return oAuthRepository.findByUserAndPlatform(user, OAuthPlatform.GOOGLE).isPresent();
 	}
 
 	@Override
 	public boolean isExists(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.GOOGLE, oAuthUserInfoDto.getId()).isPresent();
+		return oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.GOOGLE, oAuthUserInfoDto.getId()).isPresent();
 	}
 
 	private String getStringOrNull(JsonElement element, String fieldName) {

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/KakaoService.java
@@ -98,10 +98,10 @@ public class KakaoService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
 
-		if (oAuth.getDeletedAt() != null) {
+		if (oAuth.isDeleted()) {
 			throw new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND);
 		} else {
 			return oAuth;
@@ -119,12 +119,15 @@ public class KakaoService implements OAuth2Service {
 
 	@Override
 	public boolean isExists(User user) {
+		if (!user.isEnabled()) {
+			throw new BusinessException("탈퇴한 회원입니다.", StatusEnum.BAD_REQUEST);
+		}
 		return oAuthRepository.findByUserAndPlatform(user, OAuthPlatform.KAKAO).isPresent();
 	}
 
 	@Override
 	public boolean isExists(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId()).isPresent();
+		return oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.KAKAO, oAuthUserInfoDto.getId()).isPresent();
 	}
 
 	private String getStringOrNull(JsonElement element, String fieldName) {

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/NaverService.java
@@ -103,7 +103,7 @@ public class NaverService implements OAuth2Service {
 
 	@Override
 	public OAuth read(OAuthUserInfoDto oAuthUserInfoDto) {
-		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.NAVER, oAuthUserInfoDto.getId())
+		OAuth oAuth = oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.NAVER, oAuthUserInfoDto.getId())
 				.orElseThrow(() -> new BusinessException("존재하지 않는 OAuth 계정입니다.", StatusEnum.NOT_FOUND));
 
 		if (oAuth.getDeletedAt() != null) {
@@ -124,12 +124,15 @@ public class NaverService implements OAuth2Service {
 
 	@Override
 	public boolean isExists(User user) {
+		if (!user.isEnabled()) {
+			throw new BusinessException("탈퇴한 회원입니다.", StatusEnum.BAD_REQUEST);
+		}
 		return oAuthRepository.findByUserAndPlatform(user, OAuthPlatform.NAVER).isPresent();
 	}
 
 	@Override
 	public boolean isExists(OAuthUserInfoDto oAuthUserInfoDto) {
-		return oAuthRepository.findByPlatformAndPlatformId(OAuthPlatform.NAVER, oAuthUserInfoDto.getId()).isPresent();
+		return oAuthRepository.findByPlatformAndPlatformIdAndDeletedAtIsNull(OAuthPlatform.NAVER, oAuthUserInfoDto.getId()).isPresent();
 	}
 
 	private String getStringOrNull(JsonElement element, String fieldName) {

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuthService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/OAuthService.java
@@ -1,10 +1,14 @@
 package org.swmaestro.repl.gifthub.auth.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.swmaestro.repl.gifthub.auth.dto.OAuthTokenDto;
 import org.swmaestro.repl.gifthub.auth.dto.OAuthUserInfoDto;
 import org.swmaestro.repl.gifthub.auth.entity.OAuth;
 import org.swmaestro.repl.gifthub.auth.entity.User;
+import org.swmaestro.repl.gifthub.auth.repository.OAuthRepository;
 import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
 import org.swmaestro.repl.gifthub.util.StatusEnum;
@@ -21,6 +25,7 @@ public class OAuthService {
 	private final KakaoService kakaoService;
 	private final GoogleService googleService;
 	private final AppleService appleService;
+	private final OAuthRepository oAuthRepository;
 
 	public OAuthUserInfoDto getUserInfo(OAuthTokenDto oAuthTokenDto, OAuthPlatform platform) {
 		return platformToService(platform).getUserInfo(oAuthTokenDto);
@@ -54,5 +59,19 @@ public class OAuthService {
 			case APPLE -> appleService;
 			default -> throw new BusinessException("지원하지 않는 OAuth 플랫폼입니다.", StatusEnum.INTERNAL_SERVER_ERROR);
 		};
+	}
+
+	/**
+	 * 해당 유저의 전체 oauth 정보를 삭제하는 메서
+	 * @param user
+	 * @return
+	 */
+	public List<OAuth> delete(User user) {
+		List<OAuth> oAuths = oAuthRepository.findAllByUser(user);
+		for (OAuth oAuth : oAuths) {
+			oAuth.setDeletedAt(LocalDateTime.now());
+			oAuthRepository.save(oAuth);
+		}
+		return oAuths;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
@@ -142,6 +142,7 @@ public class UserService implements UserDetailsService {
 		user.setDeletedAt(LocalDateTime.now());
 		userRepository.save(user);
 
+		deleteOAuthInfo(user);
 		return MemberDeleteResponseDto.builder()
 				.id(id)
 				.build();
@@ -163,5 +164,9 @@ public class UserService implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		return userRepository.findByUsername(username).getDeletedAt() == null ? userRepository.findByUsername(username) : null;
+	}
+
+	public List<OAuth> deleteOAuthInfo(User user) {
+		return oAuthService.delete(user);
 	}
 }


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
1. google user-info response 제거
2. OAuth로 로그인 -> 회원탈퇴-> 재로그인 시 기존 유저로 로그인 되는 문제
3. 회원 탈퇴 시, OAuth 삭제 안됨 
### Problem Solving
<!-- 해결 방법 -->
1. 회원 탈퇴 시, OAuth 테이블에 있는 모든 정보 deleted_at 추가 - aeee02f61e67e02b11dabed5394449709481e98b , 64a1a6e73b7219e27c5115f6122de64bc0b4ca1f
2. JPA method 변경으로 deleted_at이 null인 것만 is_exist로 판정 - 94d7f0d449a525bf04bcff19cfdbf4b06d3573c6 , ea7ac68995c726f56f3b7d3aeb0762a5dd15013b, 930be7f1e8d361e6d5b9e8c522c7a644332c6008

### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->