### PR TITLE
Add notification agreement field in user-info-dto

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserInfoResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserInfoResponseDto.java
@@ -11,14 +11,18 @@ import lombok.Getter;
 @Getter
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UserInfoResponseDto {
+	private Long id;
 	private String username;
 	private String nickname;
 	private List<OAuthUserInfoDto> oauth;
+	public boolean allowNotifications;
 
 	@Builder
-	public UserInfoResponseDto(String username, String nickname, List<OAuthUserInfoDto> oauth) {
+	public UserInfoResponseDto(Long id, String username, String nickname, List<OAuthUserInfoDto> oauth, boolean allowNotifications) {
+		this.id = id;
 		this.username = username;
 		this.nickname = nickname;
 		this.oauth = oauth;
+		this.allowNotifications = allowNotifications;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/repository/DeviceTokenRepository.java
@@ -13,4 +13,6 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> 
 	Optional<DeviceToken> findByUserAndToken(User user, String token);
 
 	List<DeviceToken> findAllByUser(User user);
+
+	Optional<DeviceToken> findByUser(User user);
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
@@ -21,6 +21,7 @@ import org.swmaestro.repl.gifthub.auth.dto.UserUpdateRequestDto;
 import org.swmaestro.repl.gifthub.auth.dto.UserUpdateResponseDto;
 import org.swmaestro.repl.gifthub.auth.entity.OAuth;
 import org.swmaestro.repl.gifthub.auth.entity.User;
+import org.swmaestro.repl.gifthub.auth.repository.DeviceTokenRepository;
 import org.swmaestro.repl.gifthub.auth.repository.UserRepository;
 import org.swmaestro.repl.gifthub.auth.type.OAuthPlatform;
 import org.swmaestro.repl.gifthub.exception.BusinessException;
@@ -34,6 +35,7 @@ public class UserService implements UserDetailsService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final OAuthService oAuthService;
+	private final DeviceTokenRepository deviceTokenRepository;
 
 	public User passwordEncryption(User user) {
 		return User.builder()
@@ -174,10 +176,19 @@ public class UserService implements UserDetailsService {
 	public UserInfoResponseDto readInfo(String username) {
 		User user = read(username);
 		UserInfoResponseDto userInfoResponseDto = UserInfoResponseDto.builder()
+				.id(user.getId())
 				.username(username)
 				.nickname(user.getNickname())
 				.oauth(oAuthService.list(user))
+				.allowNotifications(isExistDeviceToken(user))
 				.build();
 		return userInfoResponseDto;
+	}
+
+	/**
+	 * DeviceToken 조회 메서드 (user)
+	 */
+	public boolean isExistDeviceToken(User user) {
+		return deviceTokenRepository.findByUser(user).isPresent();
 	}
 }


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
유효기간알림, 기프티콘 등록 성공/실패 여부 알림 등 정보성 알림에 대한 수신 동의 관리 필요성 대두
- 회원 가입 시 기본적으로 devicetoken을 저장
- 마이페이지에서 알림 수신 거부 시 -> devicetoken 삭제 API 호출

로 관리하기로 클라이언트와 협의함
### Problem Solving
<!-- 해결 방법 -->
- 내 정보 조회 API를 통해 해당 회원이 알림 동의 현황을 파악할 수 있도록 함
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
정보성 알림과 광고성 알림 법률의 차이가 있다는 것을 파악했고, [GH-301](https://swm-repl.atlassian.net/jira/software/projects/GH/boards/1?selectedIssue=GH-301)에 관련 자료 첨부하였습니다.


[GH-301]: https://swm-repl.atlassian.net/browse/GH-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ