### PR TITLE
Implement is-anonymous field in user-info-dto

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserInfoResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/dto/UserInfoResponseDto.java
@@ -2,6 +2,7 @@ package org.swmaestro.repl.gifthub.auth.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -16,13 +17,17 @@ public class UserInfoResponseDto {
 	private String nickname;
 	private List<OAuthUserInfoDto> oauth;
 	public boolean allowNotifications;
+	@JsonProperty("is_anonymous")
+	public boolean anonymous;
 
 	@Builder
-	public UserInfoResponseDto(Long id, String username, String nickname, List<OAuthUserInfoDto> oauth, boolean allowNotifications) {
+	public UserInfoResponseDto(Long id, String username, String nickname, List<OAuthUserInfoDto> oauth,
+			boolean allowNotifications, boolean anonymous) {
 		this.id = id;
 		this.username = username;
 		this.nickname = nickname;
 		this.oauth = oauth;
 		this.allowNotifications = allowNotifications;
+		this.anonymous = anonymous;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/entity/User.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/entity/User.java
@@ -92,4 +92,8 @@ public class User extends BaseTimeEntity implements UserDetails {
 	public boolean isEnabled() {
 		return this.deletedAt == null;
 	}
+
+	public boolean isAnonymous() {
+		return this.role == Role.ANONYMOUS;
+	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/auth/service/UserService.java
@@ -192,6 +192,7 @@ public class UserService implements UserDetailsService {
 				.nickname(user.getNickname())
 				.oauth(oAuthService.list(user))
 				.allowNotifications(isExistDeviceToken(user))
+				.anonymous(user.isAnonymous())
 				.build();
 		return userInfoResponseDto;
 	}


### PR DESCRIPTION
### PR Type
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
클라이언트로부터의 비회원 여부 정보 요청
### Problem Solving
<!-- 해결 방법 -->
user의 role 정보 응답
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
다음고 같이 구현했을 때, 응답이 이렇게 왔습니다.
1. 코드
![image](https://github.com/SWM-REPL/gifthub-was/assets/62206617/f9f8fc88-dc67-4b2b-b7d9-229aea16e508)
2. 응답
![image](https://github.com/SWM-REPL/gifthub-was/assets/62206617/c0043078-8833-494c-a510-52efac975700)

Lombok Getter와 Jackson에서 `is` prefix를 붙이면 무슨 문제가 발생하는 것 같은데, 아직 이해는 잘 못했습니다.
일단 빠른 구현을 위해 강제로 이름을 바꿔주었습니다.
슬쩍 찾아봤는데 아마 `@Getter` 랑 `Jackson`의 직렬화 문제인 것 같습니다.
[참고 자료입니다.](https://stackoverflow.com/questions/40022600/duplicate-boolean-fields-in-json)