### PR TITLE
Handle GPT exception with null barcode

### DIFF
--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -90,8 +90,10 @@ public class VoucherSaveService {
 				System.out.println("GPT response");
 				System.out.println(voucherSaveRequestDto.getBrandName());
 				System.out.println(voucherSaveRequestDto.getProductName());
-
-				if (voucherSaveRequestDto.getBrandName() == "" || voucherSaveRequestDto.getProductName() == "") {
+				System.out.println(voucherSaveRequestDto.getBarcode());
+				System.out.println(voucherSaveRequestDto.getExpiresAt());
+				if (voucherSaveRequestDto.getBrandName() == "" || voucherSaveRequestDto.getProductName() == ""
+						|| voucherSaveRequestDto.getBarcode() == "" || voucherSaveRequestDto.getExpiresAt() == "") {
 					throw new GptResponseException("GPT 응답이 올바르지 않습니다.", StatusEnum.NOT_FOUND);
 				}
 				return Mono.just(voucherSaveRequestDto);


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
barcode를 nullable로 변경하면서, GPT barcode 파싱에 실패해도 null인채로 저장됨
### Problem Solving
<!-- 해결 방법 -->
GPT의 response에서 `barcode`, `expires_at` 예외처리
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
