### PR TITLE
Detach and set up with WebClient Config

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -66,7 +66,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.2
         with:
           name: "./src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json"
-          json: ${{ secrets.FIREBASE_JSON }}
+          json: ${{ secrets.FIREBASE_DEVELOPMENT_JSON }}
 
       # Docker 이미지 build 및 push
       - name: docker build and push

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -64,7 +64,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.2
         with:
           name: "./src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json"
-          json: ${{ secrets.FIREBASE_JSON }}
+          json: ${{ secrets.FIREBASE_DEVELOPMENT_JSON }}
 
       # 5. 테스트를 위한 MySQL 설정
       - name: Setup MySQL

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Create Json
         uses: jsdaniell/create-json@v1.2.2
         with:
-          name: "./src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json"
-          json: ${{ secrets.FIREBASE_JSON }}
+          name: "./src/main/resources/firebase/gifthub-production-3d052-firebase-adminsdk-zkstv-377ec5747b.json"
+          json: ${{ secrets.FIREBASE_PRODUCTION_JSON }}
 
       # Docker 이미지 build 및 push
       - name: docker build and push

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Create Json
         uses: jsdaniell/create-json@v1.2.2
         with:
-          name: "./src/main/resources/firebase/gifthub-production-3d052-firebase-adminsdk-zkstv-377ec5747b.json"
-          json: ${{ secrets.FIREBASE_PRODUCTION_JSON }}
+          name: "./src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json"
+          json: ${{ secrets.FIREBASE_DEVELOPMENT_JSON }}
 
       # 5. 테스트를 위한 MySQL 설정
       - name: Setup MySQL

--- a/.github/workflows/prod-ci.yml
+++ b/.github/workflows/prod-ci.yml
@@ -63,8 +63,8 @@ jobs:
       - name: Create Json
         uses: jsdaniell/create-json@v1.2.2
         with:
-          name: "./src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json"
-          json: ${{ secrets.FIREBASE_JSON }}
+          name: "./src/main/resources/firebase/gifthub-production-3d052-firebase-adminsdk-zkstv-377ec5747b.json"
+          json: ${{ secrets.FIREBASE_PRODUCTION_JSON }}
 
       # 5. 테스트를 위한 MySQL 설정
       - name: Setup MySQL

--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ out/
 src/.DS_Store
 
 # Firebase
-/src/main/resources/firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json
+/src/main/resources/firebase/
 
 # Actions Secrets
 actions-secrets.yml

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,10 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
 
+configurations {
+    all*.exclude group: 'commons-logging', module: 'commons-logging'
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -71,10 +71,6 @@ dependencies {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
 }
 
-configurations {
-    all*.exclude group: 'commons-logging', module: 'commons-logging'
-}
-
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/config/FCMConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/FCMConfig.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -15,9 +16,12 @@ import com.google.firebase.messaging.FirebaseMessaging;
 
 @Configuration
 public class FCMConfig {
+	@Value("${firebase.key-path}")
+	private String keyPath;
+
 	@Bean
 	FirebaseMessaging firebaseMessaging() throws IOException {
-		ClassPathResource resource = new ClassPathResource("firebase/gifthub-b2dcb-firebase-adminsdk-yj7uq-912097b9ae.json");
+		ClassPathResource resource = new ClassPathResource(keyPath);
 
 		InputStream refreshToken = resource.getInputStream();
 

--- a/src/main/java/org/swmaestro/repl/gifthub/config/WebClientConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/WebClientConfig.java
@@ -21,9 +21,10 @@ public class WebClientConfig {
 
 	HttpClient httpClient = HttpClient.create(
 			ConnectionProvider.builder("gifthub-connections")
-					.maxConnections(2)
+					.maxConnections(100)
 					.maxIdleTime(Duration.ofSeconds(30))
 					.pendingAcquireTimeout(Duration.ofSeconds(45))
+					.pendingAcquireMaxCount(-1)
 					.evictInBackground(Duration.ofSeconds(30))
 					.lifo()
 					.build()

--- a/src/main/java/org/swmaestro/repl/gifthub/config/WebClientConfig.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/config/WebClientConfig.java
@@ -1,0 +1,31 @@
+package org.swmaestro.repl.gifthub.config;
+
+import java.time.Duration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+@Configuration
+public class WebClientConfig {
+	@Bean
+	public WebClient webClient() {
+		return WebClient.builder()
+				.clientConnector(new ReactorClientHttpConnector(httpClient))
+				.build();
+	}
+
+	HttpClient httpClient = HttpClient.create(
+			ConnectionProvider.builder("gifthub-connections")
+					.maxConnections(2)
+					.maxIdleTime(Duration.ofSeconds(30))
+					.pendingAcquireTimeout(Duration.ofSeconds(45))
+					.evictInBackground(Duration.ofSeconds(30))
+					.lifo()
+					.build()
+	);
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherController.java
@@ -27,6 +27,7 @@ import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateRequestDto;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.service.PendingVoucherService;
@@ -132,7 +133,7 @@ public class VoucherController {
 	})
 	public ResponseEntity<Message> updateVoucher(HttpServletRequest request, @PathVariable Long voucherId,
 			@RequestBody VoucherUpdateRequestDto voucherUpdateRequestDto) throws IOException {
-		VoucherSaveResponseDto updatedVoucher = voucherService.update(voucherId, voucherUpdateRequestDto);
+		VoucherUpdateResponseDto updatedVoucher = voucherService.update(voucherId, voucherUpdateRequestDto);
 		return ResponseEntity.ok(
 				SuccessMessage.builder()
 						.path(request.getRequestURI())

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUpdateResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUpdateResponseDto.java
@@ -1,0 +1,43 @@
+package org.swmaestro.repl.gifthub.vouchers.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class VoucherUpdateResponseDto {
+	private Long id;
+	private Long productId;
+	private String barcode;
+	private String expiresAt;
+	private Integer price;
+	private Integer balance;
+	private String imageUrl;
+	@JsonProperty("is_accessible")
+	private boolean accessible;
+	@JsonProperty("is_shared")
+	private boolean shared;
+
+	@Builder
+	public VoucherUpdateResponseDto(Long id, Long productId, String barcode, String expiresAt, Integer price,
+			Integer balance, String imageUrl, boolean accessible, boolean shared) {
+		this.id = id;
+		this.productId = productId;
+		this.barcode = barcode;
+		this.expiresAt = expiresAt;
+		this.price = price;
+		this.balance = balance;
+		this.imageUrl = imageUrl;
+		this.accessible = accessible;
+		this.shared = shared;
+	}
+}

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUpdateResponseDto.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/dto/VoucherUpdateResponseDto.java
@@ -26,10 +26,12 @@ public class VoucherUpdateResponseDto {
 	private boolean accessible;
 	@JsonProperty("is_shared")
 	private boolean shared;
+	@JsonProperty("is_checked")
+	private boolean checked;
 
 	@Builder
 	public VoucherUpdateResponseDto(Long id, Long productId, String barcode, String expiresAt, Integer price,
-			Integer balance, String imageUrl, boolean accessible, boolean shared) {
+			Integer balance, String imageUrl, boolean accessible, boolean shared, boolean checked) {
 		this.id = id;
 		this.productId = productId;
 		this.barcode = barcode;
@@ -39,5 +41,6 @@ public class VoucherUpdateResponseDto {
 		this.imageUrl = imageUrl;
 		this.accessible = accessible;
 		this.shared = shared;
+		this.checked = checked;
 	}
 }

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Voucher.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/entity/Voucher.java
@@ -37,7 +37,7 @@ public class Voucher extends BaseTimeEntity {
 	@JoinColumn(name = "product_id", nullable = false)
 	private Product product;
 
-	@Column(length = 12)
+	@Column(length = 16)
 	private String barcode;
 
 	@Column

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/SearchService.java
@@ -2,11 +2,9 @@ package org.swmaestro.repl.gifthub.vouchers.service;
 
 import java.util.Base64;
 
-import javax.annotation.PostConstruct;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.swmaestro.repl.gifthub.config.WebClientConfig;
 import org.swmaestro.repl.gifthub.vouchers.dto.SearchResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -21,25 +19,16 @@ public class SearchService {
 
 	@Value("${opensearch.password}")
 	private String password;
-	private String auth;
 
 	@Value("${opensearch.base-url}")
 	private String baseUrl;
 
-	private WebClient openSearchClient;
-
-	@PostConstruct
-	public void init() {
-		openSearchClient = WebClient.builder()
-				.baseUrl(baseUrl)
-				.build();
-		auth = "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
-	}
+	private final WebClientConfig webClientConfig;
 
 	public Mono<SearchResponseDto> search(String query) {
-		return openSearchClient.post()
-				.uri("/product/_search")
-				.header("Authorization", auth)
+		return webClientConfig.webClient().post()
+				.uri(baseUrl + "/product/_search")
+				.header("Authorization", "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes()))
 				.header("Content-Type", "application/json")
 				.bodyValue(query)
 				.retrieve()

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/StorageService.java
@@ -60,7 +60,7 @@ public class StorageService {
 	}
 
 	public String getDefaultImagePath(String dirName) {
-		return "https://" + cloudFrontBucketName + "/" + dirName + "/" + defaultImageFile;
+		return "https://" + cloudFrontBucketName + "/" + defaultImageFile;
 	}
 
 	public String getPresignedUrlForSaveVoucher(String dirName, String extension) {

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -102,12 +102,12 @@ public class VoucherSaveService {
 
 	public Mono<VoucherSaveRequestDto> handleSearchResponse(VoucherSaveRequestDto voucherSaveRequestDto, String username, String filename) {
 		return searchService.search(createQuery(productNameProcessor.preprocessing(voucherSaveRequestDto))).flatMap(searchResponseDto -> {
+			voucherSaveRequestDto.setImageUrl(filename);
 			try {
 				String brandName = searchResponseDto.getHits().getHitsList().get(0).getSource().getBrandName();
 				String productName = searchResponseDto.getHits().getHitsList().get(0).getSource().getProductName();
 				voucherSaveRequestDto.setBrandName(brandName);
 				voucherSaveRequestDto.setProductName(productName);
-				voucherSaveRequestDto.setImageUrl(filename);
 				System.out.println("Search response");
 				System.out.println(brandName);
 				System.out.println(productName);

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherSaveService.java
@@ -72,8 +72,8 @@ public class VoucherSaveService {
 								fcmNotificationService.sendNotification("기프티콘 등록 실패", "이미 등록된 기프티콘 입니다.", username);
 								notificationService.save(userService.read(username), null, NotificationType.REGISTERED, "이미 등록된 기프티콘 입니다.");
 							} else {
-								fcmNotificationService.sendNotification("기프티콘 등록 실패", "자동 등록에 실패했습니다. 수동 등록을 이용해 주세요.", username);
-								notificationService.save(userService.read(username), null, NotificationType.REGISTERED, "자동 등록에 실패했습니다. 수동 등록을 이용해 주세요.");
+								fcmNotificationService.sendNotification("기프티콘 등록 실패", "자동 등록에 실패했습니다. 다시 시도해 주세요.", username);
+								notificationService.save(userService.read(username), null, NotificationType.REGISTERED, "자동 등록에 실패했습니다. 다시 시도해 주세요.");
 							}
 						});
 	}
@@ -83,7 +83,7 @@ public class VoucherSaveService {
 			GptTimeoutException {
 
 		return gptService.getGptResponse(voucherAutoSaveRequestDto)
-				.timeout(Duration.ofMinutes(15))
+				.timeout(Duration.ofMinutes(5))
 				.onErrorResume(GptTimeoutException.class, throwable -> Mono.error(new GptTimeoutException()))
 				.flatMap(response -> {
 					VoucherSaveRequestDto voucherSaveRequestDto = null;

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -224,6 +224,7 @@ public class VoucherService {
 				.imageUrl(voucher.getImageUrl())
 				.accessible(voucher.getDeletedAt() == null)
 				.shared(giftCardService.isExist(voucher.getId()))
+				.checked(voucher.isChecked())
 				.build();
 	}
 

--- a/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
+++ b/src/main/java/org/swmaestro/repl/gifthub/vouchers/service/VoucherService.java
@@ -22,6 +22,7 @@ import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateRequestDto;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.entity.Brand;
@@ -164,7 +165,7 @@ public class VoucherService {
 	/*
 	기프티콘 정보 수정 메서드
 	 */
-	public VoucherSaveResponseDto update(Long voucherId, VoucherUpdateRequestDto voucherUpdateRequestDto) {
+	public VoucherUpdateResponseDto update(Long voucherId, VoucherUpdateRequestDto voucherUpdateRequestDto) {
 		Voucher voucher = voucherRepository.findById(voucherId)
 				.orElseThrow(() -> new BusinessException("존재하지 않는 상품권 입니다.", StatusEnum.NOT_FOUND));
 		// Balance 수정
@@ -211,8 +212,18 @@ public class VoucherService {
 
 		voucherRepository.save(voucher);
 
-		return VoucherSaveResponseDto.builder()
+		return VoucherUpdateResponseDto.builder()
 				.id(voucherId)
+				.accessible(voucher.getDeletedAt() == null)
+				.id(voucher.getId())
+				.productId(voucher.getProduct().getId())
+				.barcode(voucher.getBarcode())
+				.price(voucher.getProduct().getPrice())
+				.balance(voucher.getBalance())
+				.expiresAt(voucher.getExpiresAt().toString())
+				.imageUrl(voucher.getImageUrl())
+				.accessible(voucher.getDeletedAt() == null)
+				.shared(giftCardService.isExist(voucher.getId()))
 				.build();
 	}
 

--- a/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
+++ b/src/test/java/org/swmaestro/repl/gifthub/vouchers/controller/VoucherControllerTest.java
@@ -30,6 +30,7 @@ import org.swmaestro.repl.gifthub.vouchers.dto.VoucherSaveResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherShareResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateRequestDto;
+import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUpdateResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseRequestDto;
 import org.swmaestro.repl.gifthub.vouchers.dto.VoucherUseResponseDto;
 import org.swmaestro.repl.gifthub.vouchers.service.GptService;
@@ -176,20 +177,20 @@ class VoucherControllerTest {
 				.expiresAt("2023-06-15")
 				.build();
 
-		VoucherSaveResponseDto voucherSaveResponseDto = VoucherSaveResponseDto.builder()
+		VoucherUpdateResponseDto voucherUpdateResponseDto = VoucherUpdateResponseDto.builder()
 				.id(1L)
 				.build();
 
 		// when
 		when(jwtProvider.resolveToken(any())).thenReturn("my_awesome_access_token");
 		when(jwtProvider.getUsername(anyString())).thenReturn("이진우");
-		when(voucherService.update(any(), any(VoucherUpdateRequestDto.class))).thenReturn(voucherSaveResponseDto);
+		when(voucherService.update(any(), any(VoucherUpdateRequestDto.class))).thenReturn(voucherUpdateResponseDto);
 
 		// then
 		mockMvc.perform(patch("/vouchers/1")
 						.header("Authorization", "Bearer my_awesome_access_token")
 						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(voucherSaveResponseDto)))
+						.content(objectMapper.writeValueAsString(voucherUpdateResponseDto)))
 				.andExpect(status().isOk());
 	}
 


### PR DESCRIPTION
### PR Type
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 테스트 코드 작성
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 문서 작성

### Motivation 
<!-- 작성 배경 -->
기프티콘 자동 등록 요청 시, GPT 서버에 요청이 가기도 전에 `recvAddress(..) failed: Connection reset by peer` 에러가 발생하면서 끝나버림
### Problem Solving
<!-- 해결 방법 -->
1. `WebClient Config`로 분리하고 생성자 주입으로 사용되도록 개선
2. WebClient에서 다양한 설정으로 에러나지 않도록 함
	- [참고](https://velog.io/@profoundsea25/recvAddress..-failed-Connection-reset-by-peer-%ED%98%B9%EC%9D%80-Connection-prematurely-closed-BEFORE-response-%EB%8C%80%EC%B2%98%ED%95%98%EA%B8%B0)
	 	- 유휴 커넥션을 일정 주기로 제거한다.
		- maxConnection을 늘린다.
		- lifo, 즉, 나중에 반환된 커넥션을 재사용하도록 한다. 이는 커넥션의 재사용률을 높인다.
		- retry를 설정한다.
### To Reviewer
<!-- 리뷰어에게 말하고 싶은 것, 유의 깊게 봐주었으면 하는 것, 의문점 등 -->
완벽하게 해결된 것은 아니지만, 기존보다는 개선되었다고 생각합니다!